### PR TITLE
geom_alt props

### DIFF
--- a/data/421/191/525/421191525.geojson
+++ b/data/421/191/525/421191525.geojson
@@ -95,6 +95,9 @@
     },
     "wof:country":"BY",
     "wof:created":1459009695,
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"e4cbb9d2050a3c202b8e2fd7c0f13755",
     "wof:hierarchy":[
         {
@@ -106,7 +109,7 @@
         }
     ],
     "wof:id":421191525,
-    "wof:lastmodified":1566632346,
+    "wof:lastmodified":1582343798,
     "wof:name":"Narach",
     "wof:parent_id":1092004907,
     "wof:placetype":"locality",

--- a/data/856/323/95/85632395.geojson
+++ b/data/856/323/95/85632395.geojson
@@ -1124,7 +1124,6 @@
     "src:geom":"quattroshapes",
     "src:geom_alt":[
         "meso",
-        "naturalearth",
         "naturalearth"
     ],
     "src:lbl_centroid":"mapshaper",
@@ -1200,7 +1199,7 @@
         "bel",
         "rus"
     ],
-    "wof:lastmodified":1582343777,
+    "wof:lastmodified":1583222729,
     "wof:name":"Belarus",
     "wof:parent_id":102191581,
     "wof:placetype":"country",

--- a/data/856/323/95/85632395.geojson
+++ b/data/856/323/95/85632395.geojson
@@ -1123,8 +1123,9 @@
     "qs:source":"US State Department, with Natural Earth mods",
     "src:geom":"quattroshapes",
     "src:geom_alt":[
+        "meso",
         "naturalearth",
-        "meso"
+        "naturalearth"
     ],
     "src:lbl_centroid":"mapshaper",
     "src:population":"wk",
@@ -1178,6 +1179,11 @@
     },
     "wof:country":"BY",
     "wof:country_alpha3":"BLR",
+    "wof:geom_alt":[
+        "meso",
+        "naturalearth-display-terrestrial-zoom6",
+        "naturalearth"
+    ],
     "wof:geomhash":"3833ae6bdaa446bd08f9f2af0c366fb9",
     "wof:hierarchy":[
         {
@@ -1194,7 +1200,7 @@
         "bel",
         "rus"
     ],
-    "wof:lastmodified":1566630876,
+    "wof:lastmodified":1582343777,
     "wof:name":"Belarus",
     "wof:parent_id":102191581,
     "wof:placetype":"country",

--- a/data/856/692/87/85669287.geojson
+++ b/data/856/692/87/85669287.geojson
@@ -359,6 +359,9 @@
         "wk:page":"Brest Region"
     },
     "wof:country":"BY",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"3f3207ca8b9fd0382afeb8124a3bb367",
     "wof:hierarchy":[
         {
@@ -376,7 +379,7 @@
         "bel",
         "rus"
     ],
-    "wof:lastmodified":1566630874,
+    "wof:lastmodified":1582343776,
     "wof:name":"Brest",
     "wof:parent_id":85632395,
     "wof:placetype":"region",

--- a/data/856/692/91/85669291.geojson
+++ b/data/856/692/91/85669291.geojson
@@ -363,6 +363,9 @@
         "wk:page":"Gomel Region"
     },
     "wof:country":"BY",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"ee4822f0ef462a7bf5f0853820f226d7",
     "wof:hierarchy":[
         {
@@ -380,7 +383,7 @@
         "bel",
         "rus"
     ],
-    "wof:lastmodified":1566630875,
+    "wof:lastmodified":1582343776,
     "wof:name":"Gomel",
     "wof:parent_id":85632395,
     "wof:placetype":"region",

--- a/data/856/692/95/85669295.geojson
+++ b/data/856/692/95/85669295.geojson
@@ -363,6 +363,9 @@
         "wk:page":"Mogilev Region"
     },
     "wof:country":"BY",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"fb102b9509b058fe90ac888d71d10142",
     "wof:hierarchy":[
         {
@@ -380,7 +383,7 @@
         "bel",
         "rus"
     ],
-    "wof:lastmodified":1566630874,
+    "wof:lastmodified":1582343775,
     "wof:name":"Mogilev",
     "wof:parent_id":85632395,
     "wof:placetype":"region",

--- a/data/856/693/01/85669301.geojson
+++ b/data/856/693/01/85669301.geojson
@@ -353,6 +353,9 @@
         "wk:page":"Vitebsk Region"
     },
     "wof:country":"BY",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"2a4404ef0983fd15b1985a34f2b1d278",
     "wof:hierarchy":[
         {
@@ -370,7 +373,7 @@
         "bel",
         "rus"
     ],
-    "wof:lastmodified":1566630873,
+    "wof:lastmodified":1582343774,
     "wof:name":"Vitebsk",
     "wof:parent_id":85632395,
     "wof:placetype":"region",

--- a/data/856/693/05/85669305.geojson
+++ b/data/856/693/05/85669305.geojson
@@ -359,6 +359,9 @@
         "wd:id":"Q191061"
     },
     "wof:country":"BY",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"616364fbd7791c72198e099f11e8af2d",
     "wof:hierarchy":[
         {
@@ -376,7 +379,7 @@
         "bel",
         "rus"
     ],
-    "wof:lastmodified":1566630871,
+    "wof:lastmodified":1582343774,
     "wof:name":"Grodno",
     "wof:parent_id":85632395,
     "wof:placetype":"region",

--- a/data/856/693/09/85669309.geojson
+++ b/data/856/693/09/85669309.geojson
@@ -361,6 +361,9 @@
         "wk:page":"Minsk Region"
     },
     "wof:country":"BY",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"41bff470b830ee0f3c2e19875f253405",
     "wof:hierarchy":[
         {
@@ -378,7 +381,7 @@
         "bel",
         "rus"
     ],
-    "wof:lastmodified":1566630872,
+    "wof:lastmodified":1582343774,
     "wof:name":"Minsk",
     "wof:parent_id":85632395,
     "wof:placetype":"region",

--- a/data/856/693/13/85669313.geojson
+++ b/data/856/693/13/85669313.geojson
@@ -704,6 +704,9 @@
         890443331
     ],
     "wof:country":"BY",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"33da3204bbd0d1f3a11516130973a9c2",
     "wof:hierarchy":[
         {
@@ -722,7 +725,7 @@
         "bel",
         "rus"
     ],
-    "wof:lastmodified":1566630873,
+    "wof:lastmodified":1582343775,
     "wof:name":"City of Minsk",
     "wof:parent_id":85632395,
     "wof:placetype":"region",

--- a/data/859/014/05/85901405.geojson
+++ b/data/859/014/05/85901405.geojson
@@ -94,6 +94,9 @@
         "qs_pg:id":491784
     },
     "wof:country":"BY",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"bdb9be06d6e24e21c4867d496d28f69a",
     "wof:hierarchy":[
         {
@@ -109,7 +112,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1566630870,
+    "wof:lastmodified":1582343773,
     "wof:name":"Vostochnyy",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",

--- a/data/890/422/309/890422309.geojson
+++ b/data/890/422/309/890422309.geojson
@@ -232,6 +232,9 @@
     },
     "wof:country":"BY",
     "wof:created":1469051436,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"cceaab33dc1b00e07c79bba37610e827",
     "wof:hierarchy":[
         {
@@ -242,7 +245,7 @@
         }
     ],
     "wof:id":890422309,
-    "wof:lastmodified":1566632358,
+    "wof:lastmodified":1582343798,
     "wof:name":"Brest",
     "wof:parent_id":85669287,
     "wof:placetype":"county",

--- a/data/890/428/903/890428903.geojson
+++ b/data/890/428/903/890428903.geojson
@@ -77,6 +77,9 @@
     },
     "wof:country":"BY",
     "wof:created":1469051779,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"11304e99dee229198d70bd5382d830c8",
     "wof:hierarchy":[
         {
@@ -87,7 +90,7 @@
         }
     ],
     "wof:id":890428903,
-    "wof:lastmodified":1566632372,
+    "wof:lastmodified":1582343798,
     "wof:name":"Hrodna",
     "wof:parent_id":85669305,
     "wof:placetype":"county",

--- a/data/890/443/331/890443331.geojson
+++ b/data/890/443/331/890443331.geojson
@@ -721,6 +721,10 @@
     ],
     "wof:country":"BY",
     "wof:created":1469052420,
+    "wof:geom_alt":[
+        "unknown",
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"a0bc8465ddd44161f1c8482e3cfbe090",
     "wof:hierarchy":[
         {
@@ -732,7 +736,7 @@
         }
     ],
     "wof:id":890443331,
-    "wof:lastmodified":1566632374,
+    "wof:lastmodified":1582343798,
     "wof:name":"Minsk",
     "wof:parent_id":1092004873,
     "wof:placetype":"locality",

--- a/data/890/443/333/890443333.geojson
+++ b/data/890/443/333/890443333.geojson
@@ -335,6 +335,9 @@
     },
     "wof:country":"BY",
     "wof:created":1469052420,
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"10671ed0663dc33cf5a8da6bd9eb1ab1",
     "wof:hierarchy":[
         {
@@ -346,7 +349,7 @@
         }
     ],
     "wof:id":890443333,
-    "wof:lastmodified":1566632374,
+    "wof:lastmodified":1582343798,
     "wof:name":"Lida",
     "wof:parent_id":1092003631,
     "wof:placetype":"locality",

--- a/data/890/455/745/890455745.geojson
+++ b/data/890/455/745/890455745.geojson
@@ -229,6 +229,9 @@
     },
     "wof:country":"BY",
     "wof:created":1469052973,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"a7c820795f4528bf9847a294bb3a9517",
     "wof:hierarchy":[
         {
@@ -239,7 +242,7 @@
         }
     ],
     "wof:id":890455745,
-    "wof:lastmodified":1566632365,
+    "wof:lastmodified":1582343798,
     "wof:name":"Barysaw",
     "wof:parent_id":85669309,
     "wof:placetype":"county",


### PR DESCRIPTION
Fixes a portion of https://github.com/whosonfirst-data/whosonfirst-data/issues/1793

This PR:

- Adds a new `wof:geom_alt` property to any "default" WOF record that has an alt file, logic [here](https://github.com/whosonfirst-data/whosonfirst-data/issues/1793#issuecomment-587895012)
- Double checks existing `src:geom_alt` properties to ensure all alt file sources are accounted for in the property list. 

This will not require PIP work to update hierarchies.