### PR TITLE
Update properties of megacities

### DIFF
--- a/data/890/443/331/890443331.geojson
+++ b/data/890/443/331/890443331.geojson
@@ -711,6 +711,7 @@
     "wof:concordances":{
         "gn:id":625144,
         "gp:id":834463,
+        "ne:id":1159151149,
         "qs_pg:id":1027176,
         "wd:id":"Q2280",
         "wk:page":"Minsk"
@@ -738,7 +739,8 @@
         }
     ],
     "wof:id":890443331,
-    "wof:lastmodified":1607390890,
+    "wof:lastmodified":1608688179,
+    "wof:megacity":1,
     "wof:name":"Minsk",
     "wof:parent_id":1092004873,
     "wof:placetype":"locality",


### PR DESCRIPTION
Fixes a portion of https://github.com/whosonfirst-data/whosonfirst-data/issues/1547

- Updates megacity records with new:
  - concordances
  - names (if not already present)
  - label centroids
  - megacity flags
- Updates geometries of any megacity record with a `Point` geometry
- Updates parent geometries when necessary