### PR TITLE
by concordances, placetype local, and more

### DIFF
--- a/data/109/200/268/1/1092002681.geojson
+++ b/data/109/200/268/1/1092002681.geojson
@@ -217,8 +217,10 @@
     ],
     "wof:breaches":[],
     "wof:concordances":{
-        "hasc:id":"BY.BR.BA"
+        "hasc:id":"BY.BR.BA",
+        "meso:local_id":"1"
     },
+    "wof:concordances_official":"meso:local_id",
     "wof:country":"BY",
     "wof:created":1473896632,
     "wof:geomhash":"77301a33f92ce03c3302a0349724329c",
@@ -231,7 +233,7 @@
         }
     ],
     "wof:id":1092002681,
-    "wof:lastmodified":1694497834,
+    "wof:lastmodified":1695886277,
     "wof:name":"Baranavichy",
     "wof:parent_id":85669287,
     "wof:placetype":"county",

--- a/data/109/200/268/3/1092002683.geojson
+++ b/data/109/200/268/3/1092002683.geojson
@@ -148,8 +148,10 @@
     ],
     "wof:breaches":[],
     "wof:concordances":{
-        "hasc:id":"BY.BR.BZ"
+        "hasc:id":"BY.BR.BZ",
+        "meso:local_id":"2"
     },
+    "wof:concordances_official":"meso:local_id",
     "wof:country":"BY",
     "wof:created":1473896634,
     "wof:geomhash":"ec416a9ce9dbf9ecd5e1d3c1aca07e78",
@@ -162,7 +164,7 @@
         }
     ],
     "wof:id":1092002683,
-    "wof:lastmodified":1694497834,
+    "wof:lastmodified":1695886278,
     "wof:name":"Byaroza",
     "wof:parent_id":85669287,
     "wof:placetype":"county",

--- a/data/109/200/268/5/1092002685.geojson
+++ b/data/109/200/268/5/1092002685.geojson
@@ -136,8 +136,10 @@
     ],
     "wof:breaches":[],
     "wof:concordances":{
-        "hasc:id":"BY.BR.DG"
+        "hasc:id":"BY.BR.DG",
+        "meso:local_id":"4"
     },
+    "wof:concordances_official":"meso:local_id",
     "wof:country":"BY",
     "wof:created":1473896635,
     "wof:geomhash":"ab8415b5401421116139136daae7ce0b",
@@ -150,7 +152,7 @@
         }
     ],
     "wof:id":1092002685,
-    "wof:lastmodified":1694497834,
+    "wof:lastmodified":1695886278,
     "wof:name":"Drahichyn",
     "wof:parent_id":85669287,
     "wof:placetype":"county",

--- a/data/109/200/268/7/1092002687.geojson
+++ b/data/109/200/268/7/1092002687.geojson
@@ -127,8 +127,10 @@
     ],
     "wof:breaches":[],
     "wof:concordances":{
-        "hasc:id":"BY.BR.GA"
+        "hasc:id":"BY.BR.GA",
+        "meso:local_id":"5"
     },
+    "wof:concordances_official":"meso:local_id",
     "wof:country":"BY",
     "wof:created":1473896636,
     "wof:geomhash":"5634f7b04aa3863d7a0d932c1a570225",
@@ -141,7 +143,7 @@
         }
     ],
     "wof:id":1092002687,
-    "wof:lastmodified":1694497834,
+    "wof:lastmodified":1695886278,
     "wof:name":"Hantsavichy",
     "wof:parent_id":85669287,
     "wof:placetype":"county",

--- a/data/109/200/268/9/1092002689.geojson
+++ b/data/109/200/268/9/1092002689.geojson
@@ -70,8 +70,10 @@
     ],
     "wof:breaches":[],
     "wof:concordances":{
-        "hasc:id":"BY.BR.IN"
+        "hasc:id":"BY.BR.IN",
+        "meso:local_id":"6"
     },
+    "wof:concordances_official":"meso:local_id",
     "wof:country":"BY",
     "wof:created":1473896637,
     "wof:geomhash":"2710625a4b795e4636c88a6b5157276f",
@@ -84,7 +86,7 @@
         }
     ],
     "wof:id":1092002689,
-    "wof:lastmodified":1694498072,
+    "wof:lastmodified":1695886306,
     "wof:name":"Ivanaw",
     "wof:parent_id":85669287,
     "wof:placetype":"county",

--- a/data/109/200/269/1/1092002691.geojson
+++ b/data/109/200/269/1/1092002691.geojson
@@ -133,8 +133,10 @@
     ],
     "wof:breaches":[],
     "wof:concordances":{
-        "hasc:id":"BY.BR.IV"
+        "hasc:id":"BY.BR.IV",
+        "meso:local_id":"7"
     },
+    "wof:concordances_official":"meso:local_id",
     "wof:country":"BY",
     "wof:created":1473896638,
     "wof:geomhash":"aa93aac20f44176f2a54ca2db46a6bd6",
@@ -147,7 +149,7 @@
         }
     ],
     "wof:id":1092002691,
-    "wof:lastmodified":1694497834,
+    "wof:lastmodified":1695886278,
     "wof:name":"Ivatsevichy",
     "wof:parent_id":85669287,
     "wof:placetype":"county",

--- a/data/109/200/269/3/1092002693.geojson
+++ b/data/109/200/269/3/1092002693.geojson
@@ -70,8 +70,10 @@
     ],
     "wof:breaches":[],
     "wof:concordances":{
-        "hasc:id":"BY.BR.KN"
+        "hasc:id":"BY.BR.KN",
+        "meso:local_id":"8"
     },
+    "wof:concordances_official":"meso:local_id",
     "wof:country":"BY",
     "wof:created":1473896640,
     "wof:geomhash":"ac0bbe02030cb83fa557d544c55db0dd",
@@ -84,7 +86,7 @@
         }
     ],
     "wof:id":1092002693,
-    "wof:lastmodified":1694498073,
+    "wof:lastmodified":1695886312,
     "wof:name":"Kamyanyets",
     "wof:parent_id":85669287,
     "wof:placetype":"county",

--- a/data/109/200/269/5/1092002695.geojson
+++ b/data/109/200/269/5/1092002695.geojson
@@ -70,8 +70,10 @@
     ],
     "wof:breaches":[],
     "wof:concordances":{
-        "hasc:id":"BY.BR.KB"
+        "hasc:id":"BY.BR.KB",
+        "meso:local_id":"9"
     },
+    "wof:concordances_official":"meso:local_id",
     "wof:country":"BY",
     "wof:created":1473896641,
     "wof:geomhash":"ab18bb4121bd46a906f1399821dce145",
@@ -84,7 +86,7 @@
         }
     ],
     "wof:id":1092002695,
-    "wof:lastmodified":1694498073,
+    "wof:lastmodified":1695886318,
     "wof:name":"Kobryn'",
     "wof:parent_id":85669287,
     "wof:placetype":"county",

--- a/data/109/200/269/9/1092002699.geojson
+++ b/data/109/200/269/9/1092002699.geojson
@@ -139,8 +139,10 @@
     ],
     "wof:breaches":[],
     "wof:concordances":{
-        "hasc:id":"BY.BR.LU"
+        "hasc:id":"BY.BR.LU",
+        "meso:local_id":"10"
     },
+    "wof:concordances_official":"meso:local_id",
     "wof:country":"BY",
     "wof:created":1473896642,
     "wof:geomhash":"56bc81a263683824d336e96f8e2d617b",
@@ -153,7 +155,7 @@
         }
     ],
     "wof:id":1092002699,
-    "wof:lastmodified":1694497834,
+    "wof:lastmodified":1695886278,
     "wof:name":"Luninets",
     "wof:parent_id":85669287,
     "wof:placetype":"county",

--- a/data/109/200/271/3/1092002713.geojson
+++ b/data/109/200/271/3/1092002713.geojson
@@ -133,8 +133,10 @@
     ],
     "wof:breaches":[],
     "wof:concordances":{
-        "hasc:id":"BY.BR.LH"
+        "hasc:id":"BY.BR.LH",
+        "meso:local_id":"11"
     },
+    "wof:concordances_official":"meso:local_id",
     "wof:country":"BY",
     "wof:created":1473896643,
     "wof:geomhash":"9d8a6d1ceeeed0edca0ac406ab422d62",
@@ -147,7 +149,7 @@
         }
     ],
     "wof:id":1092002713,
-    "wof:lastmodified":1694497835,
+    "wof:lastmodified":1695886281,
     "wof:name":"Lyakhavichy",
     "wof:parent_id":85669287,
     "wof:placetype":"county",

--- a/data/109/200/274/7/1092002747.geojson
+++ b/data/109/200/274/7/1092002747.geojson
@@ -130,8 +130,10 @@
     ],
     "wof:breaches":[],
     "wof:concordances":{
-        "hasc:id":"BY.BR.ML"
+        "hasc:id":"BY.BR.ML",
+        "meso:local_id":"12"
     },
+    "wof:concordances_official":"meso:local_id",
     "wof:country":"BY",
     "wof:created":1473896644,
     "wof:geomhash":"7dcd0d16220a25d00c6953b017f50187",
@@ -144,7 +146,7 @@
         }
     ],
     "wof:id":1092002747,
-    "wof:lastmodified":1694497833,
+    "wof:lastmodified":1695886276,
     "wof:name":"Malaryta",
     "wof:parent_id":85669287,
     "wof:placetype":"county",

--- a/data/109/200/276/5/1092002765.geojson
+++ b/data/109/200/276/5/1092002765.geojson
@@ -211,8 +211,10 @@
     ],
     "wof:breaches":[],
     "wof:concordances":{
-        "hasc:id":"BY.BR.PI"
+        "hasc:id":"BY.BR.PI",
+        "meso:local_id":"13"
     },
+    "wof:concordances_official":"meso:local_id",
     "wof:country":"BY",
     "wof:created":1473896645,
     "wof:geomhash":"2453337799762d66764cfbe7bb04491a",
@@ -225,7 +227,7 @@
         }
     ],
     "wof:id":1092002765,
-    "wof:lastmodified":1694497835,
+    "wof:lastmodified":1695886281,
     "wof:name":"Pinsk",
     "wof:parent_id":85669287,
     "wof:placetype":"county",

--- a/data/109/200/278/5/1092002785.geojson
+++ b/data/109/200/278/5/1092002785.geojson
@@ -145,8 +145,10 @@
     ],
     "wof:breaches":[],
     "wof:concordances":{
-        "hasc:id":"BY.BR.PR"
+        "hasc:id":"BY.BR.PR",
+        "meso:local_id":"14"
     },
+    "wof:concordances_official":"meso:local_id",
     "wof:country":"BY",
     "wof:created":1473896647,
     "wof:geomhash":"73bd86c584fd824d2f754fd34a1df0fe",
@@ -159,7 +161,7 @@
         }
     ],
     "wof:id":1092002785,
-    "wof:lastmodified":1694497835,
+    "wof:lastmodified":1695886281,
     "wof:name":"Pruzhany",
     "wof:parent_id":85669287,
     "wof:placetype":"county",

--- a/data/109/200/280/9/1092002809.geojson
+++ b/data/109/200/280/9/1092002809.geojson
@@ -139,8 +139,10 @@
     ],
     "wof:breaches":[],
     "wof:concordances":{
-        "hasc:id":"BY.BR.ST"
+        "hasc:id":"BY.BR.ST",
+        "meso:local_id":"15"
     },
+    "wof:concordances_official":"meso:local_id",
     "wof:country":"BY",
     "wof:created":1473896648,
     "wof:geomhash":"0264a8f83f2507c956f8e7378e38b6d7",
@@ -153,7 +155,7 @@
         }
     ],
     "wof:id":1092002809,
-    "wof:lastmodified":1694497833,
+    "wof:lastmodified":1695886276,
     "wof:name":"Stolin",
     "wof:parent_id":85669287,
     "wof:placetype":"county",

--- a/data/109/200/283/5/1092002835.geojson
+++ b/data/109/200/283/5/1092002835.geojson
@@ -133,8 +133,10 @@
     ],
     "wof:breaches":[],
     "wof:concordances":{
-        "hasc:id":"BY.BR.ZH"
+        "hasc:id":"BY.BR.ZH",
+        "meso:local_id":"16"
     },
+    "wof:concordances_official":"meso:local_id",
     "wof:country":"BY",
     "wof:created":1473896649,
     "wof:geomhash":"cc3df9d58b08c41f760ef589e9649a8f",
@@ -147,7 +149,7 @@
         }
     ],
     "wof:id":1092002835,
-    "wof:lastmodified":1694497835,
+    "wof:lastmodified":1695886281,
     "wof:name":"Zhabinka",
     "wof:parent_id":85669287,
     "wof:placetype":"county",

--- a/data/109/200/286/5/1092002865.geojson
+++ b/data/109/200/286/5/1092002865.geojson
@@ -70,8 +70,10 @@
     ],
     "wof:breaches":[],
     "wof:concordances":{
-        "hasc:id":"BY.HO.OK"
+        "hasc:id":"BY.HO.OK",
+        "meso:local_id":"17"
     },
+    "wof:concordances_official":"meso:local_id",
     "wof:country":"BY",
     "wof:created":1473896650,
     "wof:geomhash":"ae15c6cc1803b9a114f86e258e681b67",
@@ -84,7 +86,7 @@
         }
     ],
     "wof:id":1092002865,
-    "wof:lastmodified":1694498069,
+    "wof:lastmodified":1695886247,
     "wof:name":"Aktsyabar",
     "wof:parent_id":85669291,
     "wof:placetype":"county",

--- a/data/109/200/287/5/1092002875.geojson
+++ b/data/109/200/287/5/1092002875.geojson
@@ -76,8 +76,10 @@
     ],
     "wof:breaches":[],
     "wof:concordances":{
-        "hasc:id":"BY.HO.BG"
+        "hasc:id":"BY.HO.BG",
+        "meso:local_id":"18"
     },
+    "wof:concordances_official":"meso:local_id",
     "wof:country":"BY",
     "wof:created":1473896651,
     "wof:geomhash":"8856ee11f9d64819f16a075e23ddc8e1",
@@ -90,7 +92,7 @@
         }
     ],
     "wof:id":1092002875,
-    "wof:lastmodified":1694497834,
+    "wof:lastmodified":1695886277,
     "wof:name":"Brahin",
     "wof:parent_id":85669291,
     "wof:placetype":"county",

--- a/data/109/200/289/3/1092002893.geojson
+++ b/data/109/200/289/3/1092002893.geojson
@@ -127,8 +127,10 @@
     ],
     "wof:breaches":[],
     "wof:concordances":{
-        "hasc:id":"BY.HO.BK"
+        "hasc:id":"BY.HO.BK",
+        "meso:local_id":"19"
     },
+    "wof:concordances_official":"meso:local_id",
     "wof:country":"BY",
     "wof:created":1473896652,
     "wof:geomhash":"1823293250456a15886a3165fb9dacce",
@@ -141,7 +143,7 @@
         }
     ],
     "wof:id":1092002893,
-    "wof:lastmodified":1694497834,
+    "wof:lastmodified":1695886277,
     "wof:name":"Buda-Kashalyova",
     "wof:parent_id":85669291,
     "wof:placetype":"county",

--- a/data/109/200/291/9/1092002919.geojson
+++ b/data/109/200/291/9/1092002919.geojson
@@ -139,8 +139,10 @@
     ],
     "wof:breaches":[],
     "wof:concordances":{
-        "hasc:id":"BY.HO.CC"
+        "hasc:id":"BY.HO.CC",
+        "meso:local_id":"20"
     },
+    "wof:concordances_official":"meso:local_id",
     "wof:country":"BY",
     "wof:created":1473896653,
     "wof:geomhash":"8d559440f1a3ccea5c1791fdf1807fce",
@@ -153,7 +155,7 @@
         }
     ],
     "wof:id":1092002919,
-    "wof:lastmodified":1694497836,
+    "wof:lastmodified":1695886282,
     "wof:name":"Chachersk",
     "wof:parent_id":85669291,
     "wof:placetype":"county",

--- a/data/109/200/294/5/1092002945.geojson
+++ b/data/109/200/294/5/1092002945.geojson
@@ -133,8 +133,10 @@
     ],
     "wof:breaches":[],
     "wof:concordances":{
-        "hasc:id":"BY.HO.DB"
+        "hasc:id":"BY.HO.DB",
+        "meso:local_id":"21"
     },
+    "wof:concordances_official":"meso:local_id",
     "wof:country":"BY",
     "wof:created":1473896654,
     "wof:geomhash":"2fb7d091b5b45223e26fe2cff0148a2c",
@@ -147,7 +149,7 @@
         }
     ],
     "wof:id":1092002945,
-    "wof:lastmodified":1694497834,
+    "wof:lastmodified":1695886278,
     "wof:name":"Dobrush",
     "wof:parent_id":85669291,
     "wof:placetype":"county",

--- a/data/109/200/297/7/1092002977.geojson
+++ b/data/109/200/297/7/1092002977.geojson
@@ -70,8 +70,10 @@
     ],
     "wof:breaches":[],
     "wof:concordances":{
-        "hasc:id":"BY.HO.HM"
+        "hasc:id":"BY.HO.HM",
+        "meso:local_id":"22"
     },
+    "wof:concordances_official":"meso:local_id",
     "wof:country":"BY",
     "wof:created":1473896655,
     "wof:geomhash":"4d5bcc1fbb4c773c5402aa62073db7e6",
@@ -84,7 +86,7 @@
         }
     ],
     "wof:id":1092002977,
-    "wof:lastmodified":1694498072,
+    "wof:lastmodified":1695886301,
     "wof:name":"Homyel'",
     "wof:parent_id":85669291,
     "wof:placetype":"county",

--- a/data/109/200/300/5/1092003005.geojson
+++ b/data/109/200/300/5/1092003005.geojson
@@ -136,8 +136,10 @@
     ],
     "wof:breaches":[],
     "wof:concordances":{
-        "hasc:id":"BY.HO.KA"
+        "hasc:id":"BY.HO.KA",
+        "meso:local_id":"23"
     },
+    "wof:concordances_official":"meso:local_id",
     "wof:country":"BY",
     "wof:created":1473896657,
     "wof:geomhash":"f85aed6fd7db482f82955c0b3f1dc3c5",
@@ -150,7 +152,7 @@
         }
     ],
     "wof:id":1092003005,
-    "wof:lastmodified":1694497833,
+    "wof:lastmodified":1695886275,
     "wof:name":"Kalinkavichy",
     "wof:parent_id":85669291,
     "wof:placetype":"county",

--- a/data/109/200/304/1/1092003041.geojson
+++ b/data/109/200/304/1/1092003041.geojson
@@ -268,8 +268,10 @@
     ],
     "wof:breaches":[],
     "wof:concordances":{
-        "hasc:id":"BY.HO.KO"
+        "hasc:id":"BY.HO.KO",
+        "meso:local_id":"24"
     },
+    "wof:concordances_official":"meso:local_id",
     "wof:country":"BY",
     "wof:created":1473896658,
     "wof:geomhash":"3583327e98763038e3044ab829a6c800",
@@ -282,7 +284,7 @@
         }
     ],
     "wof:id":1092003041,
-    "wof:lastmodified":1694497835,
+    "wof:lastmodified":1695886280,
     "wof:name":"Karma",
     "wof:parent_id":85669291,
     "wof:placetype":"county",

--- a/data/109/200/307/1/1092003071.geojson
+++ b/data/109/200/307/1/1092003071.geojson
@@ -133,8 +133,10 @@
     ],
     "wof:breaches":[],
     "wof:concordances":{
-        "hasc:id":"BY.HO.HN"
+        "hasc:id":"BY.HO.HN",
+        "meso:local_id":"25"
     },
+    "wof:concordances_official":"meso:local_id",
     "wof:country":"BY",
     "wof:created":1473896659,
     "wof:geomhash":"f66bd71ad4bcded3fbf86c8ebc57f0bf",
@@ -147,7 +149,7 @@
         }
     ],
     "wof:id":1092003071,
-    "wof:lastmodified":1694497833,
+    "wof:lastmodified":1695886275,
     "wof:name":"Khoyniki",
     "wof:parent_id":85669291,
     "wof:placetype":"county",

--- a/data/109/200/310/1/1092003101.geojson
+++ b/data/109/200/310/1/1092003101.geojson
@@ -112,8 +112,10 @@
     ],
     "wof:breaches":[],
     "wof:concordances":{
-        "hasc:id":"BY.HO.LO"
+        "hasc:id":"BY.HO.LO",
+        "meso:local_id":"26"
     },
+    "wof:concordances_official":"meso:local_id",
     "wof:country":"BY",
     "wof:created":1473896660,
     "wof:geomhash":"235e4ee91921857a23c68877bc0da1b4",
@@ -126,7 +128,7 @@
         }
     ],
     "wof:id":1092003101,
-    "wof:lastmodified":1694497836,
+    "wof:lastmodified":1695886283,
     "wof:name":"Loyew",
     "wof:parent_id":85669291,
     "wof:placetype":"county",

--- a/data/109/200/312/1/1092003121.geojson
+++ b/data/109/200/312/1/1092003121.geojson
@@ -70,8 +70,10 @@
     ],
     "wof:breaches":[],
     "wof:concordances":{
-        "hasc:id":"BY.HO.LC"
+        "hasc:id":"BY.HO.LC",
+        "meso:local_id":"27"
     },
+    "wof:concordances_official":"meso:local_id",
     "wof:country":"BY",
     "wof:created":1473896662,
     "wof:geomhash":"8fb233f5552bba9cccb6e46a83028a92",
@@ -84,7 +86,7 @@
         }
     ],
     "wof:id":1092003121,
-    "wof:lastmodified":1694498074,
+    "wof:lastmodified":1695886341,
     "wof:name":"Lyel'chytsy",
     "wof:parent_id":85669291,
     "wof:placetype":"county",

--- a/data/109/200/315/1/1092003151.geojson
+++ b/data/109/200/315/1/1092003151.geojson
@@ -193,8 +193,10 @@
     ],
     "wof:breaches":[],
     "wof:concordances":{
-        "hasc:id":"BY.HO.MZ"
+        "hasc:id":"BY.HO.MZ",
+        "meso:local_id":"28"
     },
+    "wof:concordances_official":"meso:local_id",
     "wof:country":"BY",
     "wof:created":1473896663,
     "wof:geomhash":"4c4ed44f5767be58c8b9946956408ca6",
@@ -207,7 +209,7 @@
         }
     ],
     "wof:id":1092003151,
-    "wof:lastmodified":1694497834,
+    "wof:lastmodified":1695886279,
     "wof:name":"Mazyr",
     "wof:parent_id":85669291,
     "wof:placetype":"county",

--- a/data/109/200/318/1/1092003181.geojson
+++ b/data/109/200/318/1/1092003181.geojson
@@ -70,8 +70,10 @@
     ],
     "wof:breaches":[],
     "wof:concordances":{
-        "hasc:id":"BY.HO.NA"
+        "hasc:id":"BY.HO.NA",
+        "meso:local_id":"29"
     },
+    "wof:concordances_official":"meso:local_id",
     "wof:country":"BY",
     "wof:created":1473896664,
     "wof:geomhash":"df237a4d7161be3f683791d4413e7666",
@@ -84,7 +86,7 @@
         }
     ],
     "wof:id":1092003181,
-    "wof:lastmodified":1694498074,
+    "wof:lastmodified":1695886357,
     "wof:name":"Narowlya",
     "wof:parent_id":85669291,
     "wof:placetype":"county",

--- a/data/109/200/320/9/1092003209.geojson
+++ b/data/109/200/320/9/1092003209.geojson
@@ -70,8 +70,10 @@
     ],
     "wof:breaches":[],
     "wof:concordances":{
-        "hasc:id":"BY.HO.PE"
+        "hasc:id":"BY.HO.PE",
+        "meso:local_id":"30"
     },
+    "wof:concordances_official":"meso:local_id",
     "wof:country":"BY",
     "wof:created":1473896665,
     "wof:geomhash":"0a597aefa1ebb2cb08a654786cfff036",
@@ -84,7 +86,7 @@
         }
     ],
     "wof:id":1092003209,
-    "wof:lastmodified":1694498075,
+    "wof:lastmodified":1695886389,
     "wof:name":"Pyetrykaw",
     "wof:parent_id":85669291,
     "wof:placetype":"county",

--- a/data/109/200/322/7/1092003227.geojson
+++ b/data/109/200/322/7/1092003227.geojson
@@ -142,8 +142,10 @@
     ],
     "wof:breaches":[],
     "wof:concordances":{
-        "hasc:id":"BY.HO.RE"
+        "hasc:id":"BY.HO.RE",
+        "meso:local_id":"31"
     },
+    "wof:concordances_official":"meso:local_id",
     "wof:country":"BY",
     "wof:created":1473896666,
     "wof:geomhash":"258b0b8dece281ae38afbf9249a2255a",
@@ -156,7 +158,7 @@
         }
     ],
     "wof:id":1092003227,
-    "wof:lastmodified":1694497835,
+    "wof:lastmodified":1695886280,
     "wof:name":"Rahachow",
     "wof:parent_id":85669291,
     "wof:placetype":"county",

--- a/data/109/200/326/3/1092003263.geojson
+++ b/data/109/200/326/3/1092003263.geojson
@@ -142,8 +142,10 @@
     ],
     "wof:breaches":[],
     "wof:concordances":{
-        "hasc:id":"BY.HO.RG"
+        "hasc:id":"BY.HO.RG",
+        "meso:local_id":"32"
     },
+    "wof:concordances_official":"meso:local_id",
     "wof:country":"BY",
     "wof:created":1473896668,
     "wof:geomhash":"ed5a397dbfac585a3e8846a36f0a1751",
@@ -156,7 +158,7 @@
         }
     ],
     "wof:id":1092003263,
-    "wof:lastmodified":1694497836,
+    "wof:lastmodified":1695886283,
     "wof:name":"Rechytsa",
     "wof:parent_id":85669291,
     "wof:placetype":"county",

--- a/data/109/200/329/7/1092003297.geojson
+++ b/data/109/200/329/7/1092003297.geojson
@@ -70,8 +70,10 @@
     ],
     "wof:breaches":[],
     "wof:concordances":{
-        "hasc:id":"BY.HO.SV"
+        "hasc:id":"BY.HO.SV",
+        "meso:local_id":"33"
     },
+    "wof:concordances_official":"meso:local_id",
     "wof:country":"BY",
     "wof:created":1473896669,
     "wof:geomhash":"643a3914822c60f5c5ae3cadff5f3105",
@@ -84,7 +86,7 @@
         }
     ],
     "wof:id":1092003297,
-    "wof:lastmodified":1694498075,
+    "wof:lastmodified":1695886393,
     "wof:name":"S'vyetlahorsk",
     "wof:parent_id":85669291,
     "wof:placetype":"county",

--- a/data/109/200/333/1/1092003331.geojson
+++ b/data/109/200/333/1/1092003331.geojson
@@ -70,8 +70,10 @@
     ],
     "wof:breaches":[],
     "wof:concordances":{
-        "hasc:id":"BY.HO.VT"
+        "hasc:id":"BY.HO.VT",
+        "meso:local_id":"34"
     },
+    "wof:concordances_official":"meso:local_id",
     "wof:country":"BY",
     "wof:created":1473896670,
     "wof:geomhash":"708d1eec754a70f0e82578fb195a3e38",
@@ -84,7 +86,7 @@
         }
     ],
     "wof:id":1092003331,
-    "wof:lastmodified":1694498077,
+    "wof:lastmodified":1695886420,
     "wof:name":"Vyetka",
     "wof:parent_id":85669291,
     "wof:placetype":"county",

--- a/data/109/200/334/7/1092003347.geojson
+++ b/data/109/200/334/7/1092003347.geojson
@@ -70,8 +70,10 @@
     ],
     "wof:breaches":[],
     "wof:concordances":{
-        "hasc:id":"BY.HO.EL"
+        "hasc:id":"BY.HO.EL",
+        "meso:local_id":"35"
     },
+    "wof:concordances_official":"meso:local_id",
     "wof:country":"BY",
     "wof:created":1473896671,
     "wof:geomhash":"492c931741c641ce0907f66285ae880e",
@@ -84,7 +86,7 @@
         }
     ],
     "wof:id":1092003347,
-    "wof:lastmodified":1694498077,
+    "wof:lastmodified":1695886427,
     "wof:name":"Yel'sk",
     "wof:parent_id":85669291,
     "wof:placetype":"county",

--- a/data/109/200/337/9/1092003379.geojson
+++ b/data/109/200/337/9/1092003379.geojson
@@ -160,8 +160,10 @@
     ],
     "wof:breaches":[],
     "wof:concordances":{
-        "hasc:id":"BY.HO.ZB"
+        "hasc:id":"BY.HO.ZB",
+        "meso:local_id":"36"
     },
+    "wof:concordances_official":"meso:local_id",
     "wof:country":"BY",
     "wof:created":1473896672,
     "wof:geomhash":"0bd3844941f0d187fe6da741e368296b",
@@ -174,7 +176,7 @@
         }
     ],
     "wof:id":1092003379,
-    "wof:lastmodified":1694497833,
+    "wof:lastmodified":1695886276,
     "wof:name":"Zhlobin",
     "wof:parent_id":85669291,
     "wof:placetype":"county",

--- a/data/109/200/341/3/1092003413.geojson
+++ b/data/109/200/341/3/1092003413.geojson
@@ -124,8 +124,10 @@
     ],
     "wof:breaches":[],
     "wof:concordances":{
-        "hasc:id":"BY.HO.ZK"
+        "hasc:id":"BY.HO.ZK",
+        "meso:local_id":"37"
     },
+    "wof:concordances_official":"meso:local_id",
     "wof:country":"BY",
     "wof:created":1473896673,
     "wof:geomhash":"df6331c1ba45eb97088c758f16451eb5",
@@ -138,7 +140,7 @@
         }
     ],
     "wof:id":1092003413,
-    "wof:lastmodified":1694497834,
+    "wof:lastmodified":1695886279,
     "wof:name":"Zhytkavichy",
     "wof:parent_id":85669291,
     "wof:placetype":"county",

--- a/data/109/200/344/7/1092003447.geojson
+++ b/data/109/200/344/7/1092003447.geojson
@@ -136,8 +136,10 @@
     ],
     "wof:breaches":[],
     "wof:concordances":{
-        "hasc:id":"BY.HR.OM"
+        "hasc:id":"BY.HR.OM",
+        "meso:local_id":"38"
     },
+    "wof:concordances_official":"meso:local_id",
     "wof:country":"BY",
     "wof:created":1473896674,
     "wof:geomhash":"07ef26d3a0023ab6157b062e6bad68d6",
@@ -150,7 +152,7 @@
         }
     ],
     "wof:id":1092003447,
-    "wof:lastmodified":1694497836,
+    "wof:lastmodified":1695886283,
     "wof:name":"Ashmyany",
     "wof:parent_id":85669305,
     "wof:placetype":"county",

--- a/data/109/200/347/9/1092003479.geojson
+++ b/data/109/200/347/9/1092003479.geojson
@@ -127,8 +127,10 @@
     ],
     "wof:breaches":[],
     "wof:concordances":{
-        "hasc:id":"BY.HR.OV"
+        "hasc:id":"BY.HR.OV",
+        "meso:local_id":"39"
     },
+    "wof:concordances_official":"meso:local_id",
     "wof:country":"BY",
     "wof:created":1473896675,
     "wof:geomhash":"854d43167ae789201651a1c8c41f74bb",
@@ -141,7 +143,7 @@
         }
     ],
     "wof:id":1092003479,
-    "wof:lastmodified":1694497835,
+    "wof:lastmodified":1695886280,
     "wof:name":"Astravyets",
     "wof:parent_id":85669305,
     "wof:placetype":"county",

--- a/data/109/200/350/5/1092003505.geojson
+++ b/data/109/200/350/5/1092003505.geojson
@@ -70,8 +70,10 @@
     ],
     "wof:breaches":[],
     "wof:concordances":{
-        "hasc:id":"BY.HR.BE"
+        "hasc:id":"BY.HR.BE",
+        "meso:local_id":"40"
     },
+    "wof:concordances_official":"meso:local_id",
     "wof:country":"BY",
     "wof:created":1473896676,
     "wof:geomhash":"11835f49900ae9d1c7c779a45796e89c",
@@ -84,7 +86,7 @@
         }
     ],
     "wof:id":1092003505,
-    "wof:lastmodified":1694498071,
+    "wof:lastmodified":1695886270,
     "wof:name":"Byerastavitsa",
     "wof:parent_id":85669305,
     "wof:placetype":"county",

--- a/data/109/200/354/1/1092003541.geojson
+++ b/data/109/200/354/1/1092003541.geojson
@@ -142,8 +142,10 @@
     ],
     "wof:breaches":[],
     "wof:concordances":{
-        "hasc:id":"BY.HR.DY"
+        "hasc:id":"BY.HR.DY",
+        "meso:local_id":"41"
     },
+    "wof:concordances_official":"meso:local_id",
     "wof:country":"BY",
     "wof:created":1473896677,
     "wof:geomhash":"9f51f5ca78d651992efe9c00058db263",
@@ -156,7 +158,7 @@
         }
     ],
     "wof:id":1092003541,
-    "wof:lastmodified":1694497833,
+    "wof:lastmodified":1695886276,
     "wof:name":"Dzyatlava",
     "wof:parent_id":85669305,
     "wof:placetype":"county",

--- a/data/109/200/357/7/1092003577.geojson
+++ b/data/109/200/357/7/1092003577.geojson
@@ -133,8 +133,10 @@
     ],
     "wof:breaches":[],
     "wof:concordances":{
-        "hasc:id":"BY.HR.IY"
+        "hasc:id":"BY.HR.IY",
+        "meso:local_id":"43"
     },
+    "wof:concordances_official":"meso:local_id",
     "wof:country":"BY",
     "wof:created":1473896679,
     "wof:geomhash":"3a8ce5b5c20b87cb8c6f867fb49dddc6",
@@ -147,7 +149,7 @@
         }
     ],
     "wof:id":1092003577,
-    "wof:lastmodified":1694497835,
+    "wof:lastmodified":1695886281,
     "wof:name":"Iwye",
     "wof:parent_id":85669305,
     "wof:placetype":"county",

--- a/data/109/200/360/9/1092003609.geojson
+++ b/data/109/200/360/9/1092003609.geojson
@@ -124,8 +124,10 @@
     ],
     "wof:breaches":[],
     "wof:concordances":{
-        "hasc:id":"BY.HR.KL"
+        "hasc:id":"BY.HR.KL",
+        "meso:local_id":"44"
     },
+    "wof:concordances_official":"meso:local_id",
     "wof:country":"BY",
     "wof:created":1473896680,
     "wof:geomhash":"fa6b7c607f3f4e31096792848ec324f3",
@@ -138,7 +140,7 @@
         }
     ],
     "wof:id":1092003609,
-    "wof:lastmodified":1694497962,
+    "wof:lastmodified":1695886226,
     "wof:name":"Karelichy",
     "wof:parent_id":85669305,
     "wof:placetype":"county",

--- a/data/109/200/363/1/1092003631.geojson
+++ b/data/109/200/363/1/1092003631.geojson
@@ -190,8 +190,10 @@
     ],
     "wof:breaches":[],
     "wof:concordances":{
-        "hasc:id":"BY.HR.LD"
+        "hasc:id":"BY.HR.LD",
+        "meso:local_id":"45"
     },
+    "wof:concordances_official":"meso:local_id",
     "wof:country":"BY",
     "wof:created":1473896681,
     "wof:geomhash":"1509ea3a84a685127db54e638c1cbe0f",
@@ -204,7 +206,7 @@
         }
     ],
     "wof:id":1092003631,
-    "wof:lastmodified":1694497833,
+    "wof:lastmodified":1695886276,
     "wof:name":"Lida",
     "wof:parent_id":85669305,
     "wof:placetype":"county",

--- a/data/109/200/366/5/1092003665.geojson
+++ b/data/109/200/366/5/1092003665.geojson
@@ -70,8 +70,10 @@
     ],
     "wof:breaches":[],
     "wof:concordances":{
-        "hasc:id":"BY.HR.MO"
+        "hasc:id":"BY.HR.MO",
+        "meso:local_id":"46"
     },
+    "wof:concordances_official":"meso:local_id",
     "wof:country":"BY",
     "wof:created":1473896682,
     "wof:geomhash":"9b55fc2b88151292528023fea2013c48",
@@ -84,7 +86,7 @@
         }
     ],
     "wof:id":1092003665,
-    "wof:lastmodified":1694498074,
+    "wof:lastmodified":1695886346,
     "wof:name":"Masty",
     "wof:parent_id":85669305,
     "wof:placetype":"county",

--- a/data/109/200/369/9/1092003699.geojson
+++ b/data/109/200/369/9/1092003699.geojson
@@ -70,8 +70,10 @@
     ],
     "wof:breaches":[],
     "wof:concordances":{
-        "hasc:id":"BY.HR.NO"
+        "hasc:id":"BY.HR.NO",
+        "meso:local_id":"47"
     },
+    "wof:concordances_official":"meso:local_id",
     "wof:country":"BY",
     "wof:created":1473896683,
     "wof:geomhash":"4da55446432e065d9aed771a25298628",
@@ -84,7 +86,7 @@
         }
     ],
     "wof:id":1092003699,
-    "wof:lastmodified":1694498074,
+    "wof:lastmodified":1695886357,
     "wof:name":"Navahradak",
     "wof:parent_id":85669305,
     "wof:placetype":"county",

--- a/data/109/200/373/5/1092003735.geojson
+++ b/data/109/200/373/5/1092003735.geojson
@@ -70,8 +70,10 @@
     ],
     "wof:breaches":[],
     "wof:concordances":{
-        "hasc:id":"BY.HR.SS"
+        "hasc:id":"BY.HR.SS",
+        "meso:local_id":"48"
     },
+    "wof:concordances_official":"meso:local_id",
     "wof:country":"BY",
     "wof:created":1473896684,
     "wof:geomhash":"1219c26859f4489d612786d4c9e53457",
@@ -84,7 +86,7 @@
         }
     ],
     "wof:id":1092003735,
-    "wof:lastmodified":1694498075,
+    "wof:lastmodified":1695886393,
     "wof:name":"S'vislach",
     "wof:parent_id":85669305,
     "wof:placetype":"county",

--- a/data/109/200/376/9/1092003769.geojson
+++ b/data/109/200/376/9/1092003769.geojson
@@ -124,8 +124,10 @@
     ],
     "wof:breaches":[],
     "wof:concordances":{
-        "hasc:id":"BY.HR.SC"
+        "hasc:id":"BY.HR.SC",
+        "meso:local_id":"49"
     },
+    "wof:concordances_official":"meso:local_id",
     "wof:country":"BY",
     "wof:created":1473896685,
     "wof:geomhash":"2848795ea667bc045899b8c2aae4a30c",
@@ -138,7 +140,7 @@
         }
     ],
     "wof:id":1092003769,
-    "wof:lastmodified":1694497835,
+    "wof:lastmodified":1695886279,
     "wof:name":"Shchuchyn",
     "wof:parent_id":85669305,
     "wof:placetype":"county",

--- a/data/109/200/378/9/1092003789.geojson
+++ b/data/109/200/378/9/1092003789.geojson
@@ -178,8 +178,10 @@
     ],
     "wof:breaches":[],
     "wof:concordances":{
-        "hasc:id":"BY.HR.SL"
+        "hasc:id":"BY.HR.SL",
+        "meso:local_id":"50"
     },
+    "wof:concordances_official":"meso:local_id",
     "wof:country":"BY",
     "wof:created":1473896686,
     "wof:geomhash":"0d26dea9ed53530465f17d1980f232af",
@@ -192,7 +194,7 @@
         }
     ],
     "wof:id":1092003789,
-    "wof:lastmodified":1694497835,
+    "wof:lastmodified":1695886280,
     "wof:name":"Slonim",
     "wof:parent_id":85669305,
     "wof:placetype":"county",

--- a/data/109/200/382/1/1092003821.geojson
+++ b/data/109/200/382/1/1092003821.geojson
@@ -70,8 +70,10 @@
     ],
     "wof:breaches":[],
     "wof:concordances":{
-        "hasc:id":"BY.HR.SN"
+        "hasc:id":"BY.HR.SN",
+        "meso:local_id":"51"
     },
+    "wof:concordances_official":"meso:local_id",
     "wof:country":"BY",
     "wof:created":1473896687,
     "wof:geomhash":"b6e187917c76c7737bdd1b72721c2eb3",
@@ -84,7 +86,7 @@
         }
     ],
     "wof:id":1092003821,
-    "wof:lastmodified":1694498075,
+    "wof:lastmodified":1695886402,
     "wof:name":"Smarhon'",
     "wof:parent_id":85669305,
     "wof:placetype":"county",

--- a/data/109/200/385/3/1092003853.geojson
+++ b/data/109/200/385/3/1092003853.geojson
@@ -70,8 +70,10 @@
     ],
     "wof:breaches":[],
     "wof:concordances":{
-        "hasc:id":"BY.HR.SN"
+        "hasc:id":"BY.HR.SN",
+        "meso:local_id":"52"
     },
+    "wof:concordances_official":"meso:local_id",
     "wof:country":"BY",
     "wof:created":1473896688,
     "wof:geomhash":"3177b39b3dd7899ae18171195070738d",
@@ -84,7 +86,7 @@
         }
     ],
     "wof:id":1092003853,
-    "wof:lastmodified":1694498075,
+    "wof:lastmodified":1695886402,
     "wof:name":"Smarhon'",
     "wof:parent_id":85669309,
     "wof:placetype":"county",

--- a/data/109/200/388/9/1092003889.geojson
+++ b/data/109/200/388/9/1092003889.geojson
@@ -172,8 +172,10 @@
     ],
     "wof:breaches":[],
     "wof:concordances":{
-        "hasc:id":"BY.HR.VL"
+        "hasc:id":"BY.HR.VL",
+        "meso:local_id":"53"
     },
+    "wof:concordances_official":"meso:local_id",
     "wof:country":"BY",
     "wof:created":1473896689,
     "wof:geomhash":"c107b827a432f2f1b025443a83ee6f6a",
@@ -186,7 +188,7 @@
         }
     ],
     "wof:id":1092003889,
-    "wof:lastmodified":1694497836,
+    "wof:lastmodified":1695886283,
     "wof:name":"Vawkavysk",
     "wof:parent_id":85669305,
     "wof:placetype":"county",

--- a/data/109/200/392/5/1092003925.geojson
+++ b/data/109/200/392/5/1092003925.geojson
@@ -121,8 +121,10 @@
     ],
     "wof:breaches":[],
     "wof:concordances":{
-        "hasc:id":"BY.HR.VR"
+        "hasc:id":"BY.HR.VR",
+        "meso:local_id":"54"
     },
+    "wof:concordances_official":"meso:local_id",
     "wof:country":"BY",
     "wof:created":1473896690,
     "wof:geomhash":"30d247058b70778cc444d620eb44fa8c",
@@ -135,7 +137,7 @@
         }
     ],
     "wof:id":1092003925,
-    "wof:lastmodified":1694497962,
+    "wof:lastmodified":1695886227,
     "wof:name":"Voranava",
     "wof:parent_id":85669305,
     "wof:placetype":"county",

--- a/data/109/200/395/9/1092003959.geojson
+++ b/data/109/200/395/9/1092003959.geojson
@@ -70,8 +70,10 @@
     ],
     "wof:breaches":[],
     "wof:concordances":{
-        "hasc:id":"BY.HR.ZE"
+        "hasc:id":"BY.HR.ZE",
+        "meso:local_id":"55"
     },
+    "wof:concordances_official":"meso:local_id",
     "wof:country":"BY",
     "wof:created":1473896692,
     "wof:geomhash":"dd926f58b130bab0c7fd593a379d9c39",
@@ -84,7 +86,7 @@
         }
     ],
     "wof:id":1092003959,
-    "wof:lastmodified":1694498077,
+    "wof:lastmodified":1695886433,
     "wof:name":"Zel'va",
     "wof:parent_id":85669305,
     "wof:placetype":"county",

--- a/data/109/200/398/9/1092003989.geojson
+++ b/data/109/200/398/9/1092003989.geojson
@@ -154,8 +154,10 @@
     ],
     "wof:breaches":[],
     "wof:concordances":{
-        "hasc:id":"BY.MA.OS"
+        "hasc:id":"BY.MA.OS",
+        "meso:local_id":"56"
     },
+    "wof:concordances_official":"meso:local_id",
     "wof:country":"BY",
     "wof:created":1473896693,
     "wof:geomhash":"d222f44866727d93a949f131fa28f856",
@@ -168,7 +170,7 @@
         }
     ],
     "wof:id":1092003989,
-    "wof:lastmodified":1694497833,
+    "wof:lastmodified":1695886276,
     "wof:name":"Asipovichy",
     "wof:parent_id":85669295,
     "wof:placetype":"county",

--- a/data/109/200/402/1/1092004021.geojson
+++ b/data/109/200/402/1/1092004021.geojson
@@ -223,8 +223,10 @@
     ],
     "wof:breaches":[],
     "wof:concordances":{
-        "hasc:id":"BY.MA.BB"
+        "hasc:id":"BY.MA.BB",
+        "meso:local_id":"57"
     },
+    "wof:concordances_official":"meso:local_id",
     "wof:country":"BY",
     "wof:created":1473896694,
     "wof:geomhash":"2d68e082387bb66e9717966581474526",
@@ -237,7 +239,7 @@
         }
     ],
     "wof:id":1092004021,
-    "wof:lastmodified":1694497836,
+    "wof:lastmodified":1695886282,
     "wof:name":"Babruysk",
     "wof:parent_id":85669295,
     "wof:placetype":"county",

--- a/data/109/200/404/5/1092004045.geojson
+++ b/data/109/200/404/5/1092004045.geojson
@@ -112,8 +112,10 @@
     ],
     "wof:breaches":[],
     "wof:concordances":{
-        "hasc:id":"BY.MA.BL"
+        "hasc:id":"BY.MA.BL",
+        "meso:local_id":"58"
     },
+    "wof:concordances_official":"meso:local_id",
     "wof:country":"BY",
     "wof:created":1473896695,
     "wof:geomhash":"34e8ba78f35d5fce9aeab8580d7f1f88",
@@ -126,7 +128,7 @@
         }
     ],
     "wof:id":1092004045,
-    "wof:lastmodified":1694497836,
+    "wof:lastmodified":1695886282,
     "wof:name":"Byalynichy",
     "wof:parent_id":85669295,
     "wof:placetype":"county",

--- a/data/109/200/406/7/1092004067.geojson
+++ b/data/109/200/406/7/1092004067.geojson
@@ -142,8 +142,10 @@
     ],
     "wof:breaches":[],
     "wof:concordances":{
-        "hasc:id":"BY.MA.BY"
+        "hasc:id":"BY.MA.BY",
+        "meso:local_id":"59"
     },
+    "wof:concordances_official":"meso:local_id",
     "wof:country":"BY",
     "wof:created":1473896696,
     "wof:geomhash":"7451d000dc53620dc0f70ecdc647eb94",
@@ -156,7 +158,7 @@
         }
     ],
     "wof:id":1092004067,
-    "wof:lastmodified":1694497834,
+    "wof:lastmodified":1695886278,
     "wof:name":"Bykhaw",
     "wof:parent_id":85669295,
     "wof:placetype":"county",

--- a/data/109/200/409/7/1092004097.geojson
+++ b/data/109/200/409/7/1092004097.geojson
@@ -133,8 +133,10 @@
     ],
     "wof:breaches":[],
     "wof:concordances":{
-        "hasc:id":"BY.MA.CS"
+        "hasc:id":"BY.MA.CS",
+        "meso:local_id":"60"
     },
+    "wof:concordances_official":"meso:local_id",
     "wof:country":"BY",
     "wof:created":1473896697,
     "wof:geomhash":"3f1330cc62b88363b622ea449572e273",
@@ -147,7 +149,7 @@
         }
     ],
     "wof:id":1092004097,
-    "wof:lastmodified":1694497834,
+    "wof:lastmodified":1695886279,
     "wof:name":"Chavusy",
     "wof:parent_id":85669295,
     "wof:placetype":"county",

--- a/data/109/200/413/1/1092004131.geojson
+++ b/data/109/200/413/1/1092004131.geojson
@@ -133,8 +133,10 @@
     ],
     "wof:breaches":[],
     "wof:concordances":{
-        "hasc:id":"BY.MA.CR"
+        "hasc:id":"BY.MA.CR",
+        "meso:local_id":"61"
     },
+    "wof:concordances_official":"meso:local_id",
     "wof:country":"BY",
     "wof:created":1473896698,
     "wof:geomhash":"1bae1dbb4b9694fc6405f3232b96c259",
@@ -147,7 +149,7 @@
         }
     ],
     "wof:id":1092004131,
-    "wof:lastmodified":1694497834,
+    "wof:lastmodified":1695886277,
     "wof:name":"Cherykaw",
     "wof:parent_id":85669295,
     "wof:placetype":"county",

--- a/data/109/200/416/1/1092004161.geojson
+++ b/data/109/200/416/1/1092004161.geojson
@@ -70,8 +70,10 @@
     ],
     "wof:breaches":[],
     "wof:concordances":{
-        "hasc:id":"BY.MA.DR"
+        "hasc:id":"BY.MA.DR",
+        "meso:local_id":"62"
     },
+    "wof:concordances_official":"meso:local_id",
     "wof:country":"BY",
     "wof:created":1473896699,
     "wof:geomhash":"1c985edeabc5801b5d4edc018bf23194",
@@ -84,7 +86,7 @@
         }
     ],
     "wof:id":1092004161,
-    "wof:lastmodified":1694498072,
+    "wof:lastmodified":1695886286,
     "wof:name":"Drybin",
     "wof:parent_id":85669295,
     "wof:placetype":"county",

--- a/data/109/200/419/7/1092004197.geojson
+++ b/data/109/200/419/7/1092004197.geojson
@@ -70,8 +70,10 @@
     ],
     "wof:breaches":[],
     "wof:concordances":{
-        "hasc:id":"BY.MA.GL"
+        "hasc:id":"BY.MA.GL",
+        "meso:local_id":"63"
     },
+    "wof:concordances_official":"meso:local_id",
     "wof:country":"BY",
     "wof:created":1473896700,
     "wof:geomhash":"3cdaf27f5b6ca2fb072f859888ca6526",
@@ -84,7 +86,7 @@
         }
     ],
     "wof:id":1092004197,
-    "wof:lastmodified":1694498072,
+    "wof:lastmodified":1695886301,
     "wof:name":"Hlusk",
     "wof:parent_id":85669295,
     "wof:placetype":"county",

--- a/data/109/200/422/5/1092004225.geojson
+++ b/data/109/200/422/5/1092004225.geojson
@@ -148,8 +148,10 @@
     ],
     "wof:breaches":[],
     "wof:concordances":{
-        "hasc:id":"BY.MA.GO"
+        "hasc:id":"BY.MA.GO",
+        "meso:local_id":"64"
     },
+    "wof:concordances_official":"meso:local_id",
     "wof:country":"BY",
     "wof:created":1473896702,
     "wof:geomhash":"b8c09ddbf508e7af8b650169cbe4e051",
@@ -162,7 +164,7 @@
         }
     ],
     "wof:id":1092004225,
-    "wof:lastmodified":1694497834,
+    "wof:lastmodified":1695886277,
     "wof:name":"Horki",
     "wof:parent_id":85669295,
     "wof:placetype":"county",

--- a/data/109/200/426/1/1092004261.geojson
+++ b/data/109/200/426/1/1092004261.geojson
@@ -70,8 +70,10 @@
     ],
     "wof:breaches":[],
     "wof:concordances":{
-        "hasc:id":"BY.MA.KS"
+        "hasc:id":"BY.MA.KS",
+        "meso:local_id":"65"
     },
+    "wof:concordances_official":"meso:local_id",
     "wof:country":"BY",
     "wof:created":1473896703,
     "wof:geomhash":"711068c7e14c5105360da55ece3c64cf",
@@ -84,7 +86,7 @@
         }
     ],
     "wof:id":1092004261,
-    "wof:lastmodified":1694498073,
+    "wof:lastmodified":1695886312,
     "wof:name":"Kas'tsyukovichy",
     "wof:parent_id":85669295,
     "wof:placetype":"county",

--- a/data/109/200/429/7/1092004297.geojson
+++ b/data/109/200/429/7/1092004297.geojson
@@ -70,8 +70,10 @@
     ],
     "wof:breaches":[],
     "wof:concordances":{
-        "hasc:id":"BY.MA.HO"
+        "hasc:id":"BY.MA.HO",
+        "meso:local_id":"66"
     },
+    "wof:concordances_official":"meso:local_id",
     "wof:country":"BY",
     "wof:created":1473896704,
     "wof:geomhash":"4b08f9f1e5bbfd912a57f7013698dffa",
@@ -84,7 +86,7 @@
         }
     ],
     "wof:id":1092004297,
-    "wof:lastmodified":1694498073,
+    "wof:lastmodified":1695886315,
     "wof:name":"Khotsimsk",
     "wof:parent_id":85669295,
     "wof:placetype":"county",

--- a/data/109/200/433/3/1092004333.geojson
+++ b/data/109/200/433/3/1092004333.geojson
@@ -124,8 +124,10 @@
     ],
     "wof:breaches":[],
     "wof:concordances":{
-        "hasc:id":"BY.MA.KI"
+        "hasc:id":"BY.MA.KI",
+        "meso:local_id":"67"
     },
+    "wof:concordances_official":"meso:local_id",
     "wof:country":"BY",
     "wof:created":1473896705,
     "wof:geomhash":"afddb9840753bd8f06e2e23e844ddcf7",
@@ -138,7 +140,7 @@
         }
     ],
     "wof:id":1092004333,
-    "wof:lastmodified":1694497836,
+    "wof:lastmodified":1695886282,
     "wof:name":"Kirawsk",
     "wof:parent_id":85669295,
     "wof:placetype":"county",

--- a/data/109/200/434/9/1092004349.geojson
+++ b/data/109/200/434/9/1092004349.geojson
@@ -124,8 +124,10 @@
     ],
     "wof:breaches":[],
     "wof:concordances":{
-        "hasc:id":"BY.MA.KI"
+        "hasc:id":"BY.MA.KI",
+        "meso:local_id":"68"
     },
+    "wof:concordances_official":"meso:local_id",
     "wof:country":"BY",
     "wof:created":1473896706,
     "wof:geomhash":"2fc54d737db84f43b8820af3a06b7ddc",
@@ -138,7 +140,7 @@
         }
     ],
     "wof:id":1092004349,
-    "wof:lastmodified":1694497836,
+    "wof:lastmodified":1695886282,
     "wof:name":"Kirawsk",
     "wof:parent_id":85669291,
     "wof:placetype":"county",

--- a/data/109/200/437/3/1092004373.geojson
+++ b/data/109/200/437/3/1092004373.geojson
@@ -127,8 +127,10 @@
     ],
     "wof:breaches":[],
     "wof:concordances":{
-        "hasc:id":"BY.MA.KC"
+        "hasc:id":"BY.MA.KC",
+        "meso:local_id":"69"
     },
+    "wof:concordances_official":"meso:local_id",
     "wof:country":"BY",
     "wof:created":1473896707,
     "wof:geomhash":"8084d0d541c6b1a6ed9941027053a975",
@@ -141,7 +143,7 @@
         }
     ],
     "wof:id":1092004373,
-    "wof:lastmodified":1694497834,
+    "wof:lastmodified":1695886278,
     "wof:name":"Klichaw",
     "wof:parent_id":85669295,
     "wof:placetype":"county",

--- a/data/109/200/440/9/1092004409.geojson
+++ b/data/109/200/440/9/1092004409.geojson
@@ -136,8 +136,10 @@
     ],
     "wof:breaches":[],
     "wof:concordances":{
-        "hasc:id":"BY.MA.KM"
+        "hasc:id":"BY.MA.KM",
+        "meso:local_id":"70"
     },
+    "wof:concordances_official":"meso:local_id",
     "wof:country":"BY",
     "wof:created":1473896708,
     "wof:geomhash":"66a875185b616b1cc781a9b73bf18a73",
@@ -150,7 +152,7 @@
         }
     ],
     "wof:id":1092004409,
-    "wof:lastmodified":1694497833,
+    "wof:lastmodified":1695886276,
     "wof:name":"Klimavichy",
     "wof:parent_id":85669295,
     "wof:placetype":"county",

--- a/data/109/200/444/1/1092004441.geojson
+++ b/data/109/200/444/1/1092004441.geojson
@@ -70,8 +70,10 @@
     ],
     "wof:breaches":[],
     "wof:concordances":{
-        "hasc:id":"BY.MA.KP"
+        "hasc:id":"BY.MA.KP",
+        "meso:local_id":"71"
     },
+    "wof:concordances_official":"meso:local_id",
     "wof:country":"BY",
     "wof:created":1473896709,
     "wof:geomhash":"269c8915f44ae6b2f3070729fa6b8127",
@@ -84,7 +86,7 @@
         }
     ],
     "wof:id":1092004441,
-    "wof:lastmodified":1694498073,
+    "wof:lastmodified":1695886322,
     "wof:name":"Krasnapol'lye",
     "wof:parent_id":85669295,
     "wof:placetype":"county",

--- a/data/109/200/447/1/1092004471.geojson
+++ b/data/109/200/447/1/1092004471.geojson
@@ -70,8 +70,10 @@
     ],
     "wof:breaches":[],
     "wof:concordances":{
-        "hasc:id":"BY.MA.KG"
+        "hasc:id":"BY.MA.KG",
+        "meso:local_id":"72"
     },
+    "wof:concordances_official":"meso:local_id",
     "wof:country":"BY",
     "wof:created":1473896710,
     "wof:geomhash":"23d9161d63d5069ab6a2af9f7b537ae5",
@@ -84,7 +86,7 @@
         }
     ],
     "wof:id":1092004471,
-    "wof:lastmodified":1694498073,
+    "wof:lastmodified":1695886326,
     "wof:name":"Kruhlaye",
     "wof:parent_id":85669295,
     "wof:placetype":"county",

--- a/data/109/200/449/9/1092004499.geojson
+++ b/data/109/200/449/9/1092004499.geojson
@@ -139,8 +139,10 @@
     ],
     "wof:breaches":[],
     "wof:concordances":{
-        "hasc:id":"BY.MA.KR"
+        "hasc:id":"BY.MA.KR",
+        "meso:local_id":"73"
     },
+    "wof:concordances_official":"meso:local_id",
     "wof:country":"BY",
     "wof:created":1473896712,
     "wof:geomhash":"77d3836fad8eaa04b14658d4629a2f17",
@@ -153,7 +155,7 @@
         }
     ],
     "wof:id":1092004499,
-    "wof:lastmodified":1694497834,
+    "wof:lastmodified":1695886277,
     "wof:name":"Krychaw",
     "wof:parent_id":85669295,
     "wof:placetype":"county",

--- a/data/109/200/452/5/1092004525.geojson
+++ b/data/109/200/452/5/1092004525.geojson
@@ -76,8 +76,10 @@
     ],
     "wof:breaches":[],
     "wof:concordances":{
-        "hasc:id":"BY.MA.MH"
+        "hasc:id":"BY.MA.MH",
+        "meso:local_id":"74"
     },
+    "wof:concordances_official":"meso:local_id",
     "wof:country":"BY",
     "wof:created":1473896713,
     "wof:geomhash":"fde7d883b530aa5bd595c4541a37e885",
@@ -90,7 +92,7 @@
         }
     ],
     "wof:id":1092004525,
-    "wof:lastmodified":1694498105,
+    "wof:lastmodified":1695886753,
     "wof:name":"Mahilyow",
     "wof:parent_id":85669295,
     "wof:placetype":"county",

--- a/data/109/200/455/3/1092004553.geojson
+++ b/data/109/200/455/3/1092004553.geojson
@@ -70,8 +70,10 @@
     ],
     "wof:breaches":[],
     "wof:concordances":{
-        "hasc:id":"BY.MA.MS"
+        "hasc:id":"BY.MA.MS",
+        "meso:local_id":"75"
     },
+    "wof:concordances_official":"meso:local_id",
     "wof:country":"BY",
     "wof:created":1473896714,
     "wof:geomhash":"c8e793ad9b79343cf18ca93d90756f87",
@@ -84,7 +86,7 @@
         }
     ],
     "wof:id":1092004553,
-    "wof:lastmodified":1694498074,
+    "wof:lastmodified":1695886353,
     "wof:name":"Ms'tsislaw",
     "wof:parent_id":85669295,
     "wof:placetype":"county",

--- a/data/109/200/458/9/1092004589.geojson
+++ b/data/109/200/458/9/1092004589.geojson
@@ -145,8 +145,10 @@
     ],
     "wof:breaches":[],
     "wof:concordances":{
-        "hasc:id":"BY.MA.SH"
+        "hasc:id":"BY.MA.SH",
+        "meso:local_id":"76"
     },
+    "wof:concordances_official":"meso:local_id",
     "wof:country":"BY",
     "wof:created":1473896715,
     "wof:geomhash":"860a320d2465a7c12e1413f1fcf6f650",
@@ -159,7 +161,7 @@
         }
     ],
     "wof:id":1092004589,
-    "wof:lastmodified":1694497835,
+    "wof:lastmodified":1695886282,
     "wof:name":"Shklow",
     "wof:parent_id":85669295,
     "wof:placetype":"county",

--- a/data/109/200/460/7/1092004607.geojson
+++ b/data/109/200/460/7/1092004607.geojson
@@ -139,8 +139,10 @@
     ],
     "wof:breaches":[],
     "wof:concordances":{
-        "hasc:id":"BY.MA.SG"
+        "hasc:id":"BY.MA.SG",
+        "meso:local_id":"77"
     },
+    "wof:concordances_official":"meso:local_id",
     "wof:country":"BY",
     "wof:created":1473896716,
     "wof:geomhash":"57d3ecee90fc16752feceea813cff3b8",
@@ -153,7 +155,7 @@
         }
     ],
     "wof:id":1092004607,
-    "wof:lastmodified":1694497836,
+    "wof:lastmodified":1695886282,
     "wof:name":"Slawharad",
     "wof:parent_id":85669295,
     "wof:placetype":"county",

--- a/data/109/200/462/5/1092004625.geojson
+++ b/data/109/200/462/5/1092004625.geojson
@@ -70,8 +70,10 @@
     ],
     "wof:breaches":[],
     "wof:concordances":{
-        "hasc:id":"BY.MI.BN"
+        "hasc:id":"BY.MI.BN",
+        "meso:local_id":"79"
     },
+    "wof:concordances_official":"meso:local_id",
     "wof:country":"BY",
     "wof:created":1473896717,
     "wof:geomhash":"3a7d132273d3f579e6df3dfbc3a87366",
@@ -84,7 +86,7 @@
         }
     ],
     "wof:id":1092004625,
-    "wof:lastmodified":1694498071,
+    "wof:lastmodified":1695886270,
     "wof:name":"Byarezan'",
     "wof:parent_id":85669309,
     "wof:placetype":"county",

--- a/data/109/200/463/7/1092004637.geojson
+++ b/data/109/200/463/7/1092004637.geojson
@@ -70,8 +70,10 @@
     ],
     "wof:breaches":[],
     "wof:concordances":{
-        "hasc:id":"BY.MI.CH"
+        "hasc:id":"BY.MI.CH",
+        "meso:local_id":"80"
     },
+    "wof:concordances_official":"meso:local_id",
     "wof:country":"BY",
     "wof:created":1473896718,
     "wof:geomhash":"87c1d11455cfe6ecea6d3462ee83b25d",
@@ -84,7 +86,7 @@
         }
     ],
     "wof:id":1092004637,
-    "wof:lastmodified":1694498071,
+    "wof:lastmodified":1695886277,
     "wof:name":"Chervyen'",
     "wof:parent_id":85669309,
     "wof:placetype":"county",

--- a/data/109/200/467/3/1092004673.geojson
+++ b/data/109/200/467/3/1092004673.geojson
@@ -151,8 +151,10 @@
     ],
     "wof:breaches":[],
     "wof:concordances":{
-        "hasc:id":"BY.MI.DZ"
+        "hasc:id":"BY.MI.DZ",
+        "meso:local_id":"81"
     },
+    "wof:concordances_official":"meso:local_id",
     "wof:country":"BY",
     "wof:created":1473896719,
     "wof:geomhash":"4113de59d02d558f3dfe68f18f1bf87e",
@@ -165,7 +167,7 @@
         }
     ],
     "wof:id":1092004673,
-    "wof:lastmodified":1694497836,
+    "wof:lastmodified":1695886282,
     "wof:name":"Dzyarzhynsk",
     "wof:parent_id":85669309,
     "wof:placetype":"county",

--- a/data/109/200/470/7/1092004707.geojson
+++ b/data/109/200/470/7/1092004707.geojson
@@ -70,8 +70,10 @@
     ],
     "wof:breaches":[],
     "wof:concordances":{
-        "hasc:id":"BY.MI.KY"
+        "hasc:id":"BY.MI.KY",
+        "meso:local_id":"82"
     },
+    "wof:concordances_official":"meso:local_id",
     "wof:country":"BY",
     "wof:created":1473896720,
     "wof:geomhash":"c661c41b86d61100e2862bcc95d9aa17",
@@ -84,7 +86,7 @@
         }
     ],
     "wof:id":1092004707,
-    "wof:lastmodified":1694498073,
+    "wof:lastmodified":1695886312,
     "wof:name":"Kapyl'",
     "wof:parent_id":85669309,
     "wof:placetype":"county",

--- a/data/109/200/472/1/1092004721.geojson
+++ b/data/109/200/472/1/1092004721.geojson
@@ -70,8 +70,10 @@
     ],
     "wof:breaches":[],
     "wof:concordances":{
-        "hasc:id":"BY.MI.KT"
+        "hasc:id":"BY.MI.KT",
+        "meso:local_id":"83"
     },
+    "wof:concordances_official":"meso:local_id",
     "wof:country":"BY",
     "wof:created":1473896721,
     "wof:geomhash":"a92f1faba4bdf8ddd3772c364328effa",
@@ -84,7 +86,7 @@
         }
     ],
     "wof:id":1092004721,
-    "wof:lastmodified":1694498073,
+    "wof:lastmodified":1695886318,
     "wof:name":"Klyetsak",
     "wof:parent_id":85669309,
     "wof:placetype":"county",

--- a/data/109/200/475/3/1092004753.geojson
+++ b/data/109/200/475/3/1092004753.geojson
@@ -124,8 +124,10 @@
     ],
     "wof:breaches":[],
     "wof:concordances":{
-        "hasc:id":"BY.MI.KK"
+        "hasc:id":"BY.MI.KK",
+        "meso:local_id":"84"
     },
+    "wof:concordances_official":"meso:local_id",
     "wof:country":"BY",
     "wof:created":1473896722,
     "wof:geomhash":"360ea093b3e843607b9d89b1bc2bdb39",
@@ -138,7 +140,7 @@
         }
     ],
     "wof:id":1092004753,
-    "wof:lastmodified":1694497835,
+    "wof:lastmodified":1695886281,
     "wof:name":"Krupki",
     "wof:parent_id":85669309,
     "wof:placetype":"county",

--- a/data/109/200/478/1/1092004781.geojson
+++ b/data/109/200/478/1/1092004781.geojson
@@ -139,8 +139,10 @@
     ],
     "wof:breaches":[],
     "wof:concordances":{
-        "hasc:id":"BY.MI.LG"
+        "hasc:id":"BY.MI.LG",
+        "meso:local_id":"85"
     },
+    "wof:concordances_official":"meso:local_id",
     "wof:country":"BY",
     "wof:created":1473896723,
     "wof:geomhash":"5ac085ff5c96b95a1a6900256c9bb9af",
@@ -153,7 +155,7 @@
         }
     ],
     "wof:id":1092004781,
-    "wof:lastmodified":1694497834,
+    "wof:lastmodified":1695886277,
     "wof:name":"Lahoysk",
     "wof:parent_id":85669309,
     "wof:placetype":"county",

--- a/data/109/200/481/3/1092004813.geojson
+++ b/data/109/200/481/3/1092004813.geojson
@@ -70,8 +70,10 @@
     ],
     "wof:breaches":[],
     "wof:concordances":{
-        "hasc:id":"BY.MI.LB"
+        "hasc:id":"BY.MI.LB",
+        "meso:local_id":"86"
     },
+    "wof:concordances_official":"meso:local_id",
     "wof:country":"BY",
     "wof:created":1473896724,
     "wof:geomhash":"2c2ef5b6eb5c327a6a46fe6a6aef1608",
@@ -84,7 +86,7 @@
         }
     ],
     "wof:id":1092004813,
-    "wof:lastmodified":1694498074,
+    "wof:lastmodified":1695886341,
     "wof:name":"Lyuban'",
     "wof:parent_id":85669309,
     "wof:placetype":"county",

--- a/data/109/200/484/5/1092004845.geojson
+++ b/data/109/200/484/5/1092004845.geojson
@@ -70,8 +70,10 @@
     ],
     "wof:breaches":[],
     "wof:concordances":{
-        "hasc:id":"BY.MI.MD"
+        "hasc:id":"BY.MI.MD",
+        "meso:local_id":"87"
     },
+    "wof:concordances_official":"meso:local_id",
     "wof:country":"BY",
     "wof:created":1473896725,
     "wof:geomhash":"c4814831554e044edc4083ce9a03f144",
@@ -84,7 +86,7 @@
         }
     ],
     "wof:id":1092004845,
-    "wof:lastmodified":1694498074,
+    "wof:lastmodified":1695886343,
     "wof:name":"Maladechna",
     "wof:parent_id":85669309,
     "wof:placetype":"county",

--- a/data/109/200/490/7/1092004907.geojson
+++ b/data/109/200/490/7/1092004907.geojson
@@ -136,8 +136,10 @@
     ],
     "wof:breaches":[],
     "wof:concordances":{
-        "hasc:id":"BY.MI.MY"
+        "hasc:id":"BY.MI.MY",
+        "meso:local_id":"89"
     },
+    "wof:concordances_official":"meso:local_id",
     "wof:country":"BY",
     "wof:created":1473896728,
     "wof:geomhash":"91a7cf69757a98789c6e9ce4bec6d2cf",
@@ -150,7 +152,7 @@
         }
     ],
     "wof:id":1092004907,
-    "wof:lastmodified":1694497834,
+    "wof:lastmodified":1695886278,
     "wof:name":"Myadzyel",
     "wof:parent_id":85669309,
     "wof:placetype":"county",

--- a/data/109/200/493/5/1092004935.geojson
+++ b/data/109/200/493/5/1092004935.geojson
@@ -70,8 +70,10 @@
     ],
     "wof:breaches":[],
     "wof:concordances":{
-        "hasc:id":"BY.MI.NE"
+        "hasc:id":"BY.MI.NE",
+        "meso:local_id":"90"
     },
+    "wof:concordances_official":"meso:local_id",
     "wof:country":"BY",
     "wof:created":1473896729,
     "wof:geomhash":"725b164977d780592ba987e5713b5a38",
@@ -84,7 +86,7 @@
         }
     ],
     "wof:id":1092004935,
-    "wof:lastmodified":1694498074,
+    "wof:lastmodified":1695886363,
     "wof:name":"Nyas'vizh",
     "wof:parent_id":85669309,
     "wof:placetype":"county",

--- a/data/109/200/496/7/1092004967.geojson
+++ b/data/109/200/496/7/1092004967.geojson
@@ -79,8 +79,10 @@
     ],
     "wof:breaches":[],
     "wof:concordances":{
-        "hasc:id":"BY.MI.PU"
+        "hasc:id":"BY.MI.PU",
+        "meso:local_id":"91"
     },
+    "wof:concordances_official":"meso:local_id",
     "wof:country":"BY",
     "wof:created":1473896730,
     "wof:geomhash":"7ef1b49179e79b5f31863fc533fba6f9",
@@ -93,7 +95,7 @@
         }
     ],
     "wof:id":1092004967,
-    "wof:lastmodified":1694498075,
+    "wof:lastmodified":1695886387,
     "wof:name":"Pukhavichy",
     "wof:parent_id":85669309,
     "wof:placetype":"county",

--- a/data/109/200/498/9/1092004989.geojson
+++ b/data/109/200/498/9/1092004989.geojson
@@ -181,8 +181,10 @@
     ],
     "wof:breaches":[],
     "wof:concordances":{
-        "hasc:id":"BY.MI.SO"
+        "hasc:id":"BY.MI.SO",
+        "meso:local_id":"92"
     },
+    "wof:concordances_official":"meso:local_id",
     "wof:country":"BY",
     "wof:created":1473896731,
     "wof:geomhash":"50edb899d9ded1338da57f87ac40dd1c",
@@ -195,7 +197,7 @@
         }
     ],
     "wof:id":1092004989,
-    "wof:lastmodified":1694497834,
+    "wof:lastmodified":1695886279,
     "wof:name":"Salihorsk",
     "wof:parent_id":85669309,
     "wof:placetype":"county",

--- a/data/109/200/502/1/1092005021.geojson
+++ b/data/109/200/502/1/1092005021.geojson
@@ -70,8 +70,10 @@
     ],
     "wof:breaches":[],
     "wof:concordances":{
-        "hasc:id":"BY.MI.SK"
+        "hasc:id":"BY.MI.SK",
+        "meso:local_id":"93"
     },
+    "wof:concordances_official":"meso:local_id",
     "wof:country":"BY",
     "wof:created":1473896732,
     "wof:geomhash":"b241ffaa5b8465b18cbabca0ee4be0a5",
@@ -84,7 +86,7 @@
         }
     ],
     "wof:id":1092005021,
-    "wof:lastmodified":1694498075,
+    "wof:lastmodified":1695886402,
     "wof:name":"Slutsak",
     "wof:parent_id":85669309,
     "wof:placetype":"county",

--- a/data/109/200/505/7/1092005057.geojson
+++ b/data/109/200/505/7/1092005057.geojson
@@ -142,8 +142,10 @@
     ],
     "wof:breaches":[],
     "wof:concordances":{
-        "hasc:id":"BY.MI.SM"
+        "hasc:id":"BY.MI.SM",
+        "meso:local_id":"94"
     },
+    "wof:concordances_official":"meso:local_id",
     "wof:country":"BY",
     "wof:created":1473896733,
     "wof:geomhash":"3090dbe84f11bf8e88e1cfe7d1564082",
@@ -156,7 +158,7 @@
         }
     ],
     "wof:id":1092005057,
-    "wof:lastmodified":1694497833,
+    "wof:lastmodified":1695886276,
     "wof:name":"Smalyavichy",
     "wof:parent_id":85669309,
     "wof:placetype":"county",

--- a/data/109/200/508/9/1092005089.geojson
+++ b/data/109/200/508/9/1092005089.geojson
@@ -127,8 +127,10 @@
     ],
     "wof:breaches":[],
     "wof:concordances":{
-        "hasc:id":"BY.MI.SD"
+        "hasc:id":"BY.MI.SD",
+        "meso:local_id":"95"
     },
+    "wof:concordances_official":"meso:local_id",
     "wof:country":"BY",
     "wof:created":1473896734,
     "wof:geomhash":"a45ae93c8855e41e40849da96c151e1f",
@@ -141,7 +143,7 @@
         }
     ],
     "wof:id":1092005089,
-    "wof:lastmodified":1694497835,
+    "wof:lastmodified":1695886280,
     "wof:name":"Staryya Darohi",
     "wof:parent_id":85669309,
     "wof:placetype":"county",

--- a/data/109/200/511/9/1092005119.geojson
+++ b/data/109/200/511/9/1092005119.geojson
@@ -70,8 +70,10 @@
     ],
     "wof:breaches":[],
     "wof:concordances":{
-        "hasc:id":"BY.MI.SB"
+        "hasc:id":"BY.MI.SB",
+        "meso:local_id":"96"
     },
+    "wof:concordances_official":"meso:local_id",
     "wof:country":"BY",
     "wof:created":1473896735,
     "wof:geomhash":"26da9228262819f6d85f0c8197a36047",
@@ -84,7 +86,7 @@
         }
     ],
     "wof:id":1092005119,
-    "wof:lastmodified":1694498076,
+    "wof:lastmodified":1695886404,
     "wof:name":"Stowptsy",
     "wof:parent_id":85669309,
     "wof:placetype":"county",

--- a/data/109/200/513/1/1092005131.geojson
+++ b/data/109/200/513/1/1092005131.geojson
@@ -133,8 +133,10 @@
     ],
     "wof:breaches":[],
     "wof:concordances":{
-        "hasc:id":"BY.MI.UZ"
+        "hasc:id":"BY.MI.UZ",
+        "meso:local_id":"97"
     },
+    "wof:concordances_official":"meso:local_id",
     "wof:country":"BY",
     "wof:created":1473896736,
     "wof:geomhash":"4e141321344f5491354a8d107c5d2a40",
@@ -147,7 +149,7 @@
         }
     ],
     "wof:id":1092005131,
-    "wof:lastmodified":1694497836,
+    "wof:lastmodified":1695886283,
     "wof:name":"Uzda",
     "wof:parent_id":85669309,
     "wof:placetype":"county",

--- a/data/109/200/514/3/1092005143.geojson
+++ b/data/109/200/514/3/1092005143.geojson
@@ -145,8 +145,10 @@
     ],
     "wof:breaches":[],
     "wof:concordances":{
-        "hasc:id":"BY.MI.VZ"
+        "hasc:id":"BY.MI.VZ",
+        "meso:local_id":"98"
     },
+    "wof:concordances_official":"meso:local_id",
     "wof:country":"BY",
     "wof:created":1473896737,
     "wof:geomhash":"0f531600db717f62f6fe9365135b5cca",
@@ -159,7 +161,7 @@
         }
     ],
     "wof:id":1092005143,
-    "wof:lastmodified":1694497836,
+    "wof:lastmodified":1695886283,
     "wof:name":"Valozhyn",
     "wof:parent_id":85669309,
     "wof:placetype":"county",

--- a/data/109/200/514/7/1092005147.geojson
+++ b/data/109/200/514/7/1092005147.geojson
@@ -70,8 +70,10 @@
     ],
     "wof:breaches":[],
     "wof:concordances":{
-        "hasc:id":"BY.MI.VI"
+        "hasc:id":"BY.MI.VI",
+        "meso:local_id":"99"
     },
+    "wof:concordances_official":"meso:local_id",
     "wof:country":"BY",
     "wof:created":1473896738,
     "wof:geomhash":"db5168774a05758e58e2acf6ea10709d",
@@ -84,7 +86,7 @@
         }
     ],
     "wof:id":1092005147,
-    "wof:lastmodified":1694498077,
+    "wof:lastmodified":1695886418,
     "wof:name":"Vyalyeyka",
     "wof:parent_id":85669309,
     "wof:placetype":"county",

--- a/data/109/200/514/9/1092005149.geojson
+++ b/data/109/200/514/9/1092005149.geojson
@@ -70,8 +70,10 @@
     ],
     "wof:breaches":[],
     "wof:concordances":{
-        "hasc:id":"BY.VI.OR"
+        "hasc:id":"BY.VI.OR",
+        "meso:local_id":"100"
     },
+    "wof:concordances_official":"meso:local_id",
     "wof:country":"BY",
     "wof:created":1473896739,
     "wof:geomhash":"569826b3537ef544deace55652d0d7e0",
@@ -84,7 +86,7 @@
         }
     ],
     "wof:id":1092005149,
-    "wof:lastmodified":1694498070,
+    "wof:lastmodified":1695886250,
     "wof:name":"Arsha",
     "wof:parent_id":85669301,
     "wof:placetype":"county",

--- a/data/109/200/515/1/1092005151.geojson
+++ b/data/109/200/515/1/1092005151.geojson
@@ -139,8 +139,10 @@
     ],
     "wof:breaches":[],
     "wof:concordances":{
-        "hasc:id":"BY.VI.BV"
+        "hasc:id":"BY.VI.BV",
+        "meso:local_id":"101"
     },
+    "wof:concordances_official":"meso:local_id",
     "wof:country":"BY",
     "wof:created":1473896740,
     "wof:geomhash":"6441b3a881f3ca09f18727f383326d11",
@@ -153,7 +155,7 @@
         }
     ],
     "wof:id":1092005151,
-    "wof:lastmodified":1694497836,
+    "wof:lastmodified":1695886284,
     "wof:name":"Braslaw",
     "wof:parent_id":85669301,
     "wof:placetype":"county",

--- a/data/109/200/515/7/1092005157.geojson
+++ b/data/109/200/515/7/1092005157.geojson
@@ -70,8 +70,10 @@
     ],
     "wof:breaches":[],
     "wof:concordances":{
-        "hasc:id":"BY.VI.BS"
+        "hasc:id":"BY.VI.BS",
+        "meso:local_id":"102"
     },
+    "wof:concordances_official":"meso:local_id",
     "wof:country":"BY",
     "wof:created":1473896742,
     "wof:geomhash":"da8d9f7f34022ea4b35e5ad37d49e5e3",
@@ -84,7 +86,7 @@
         }
     ],
     "wof:id":1092005157,
-    "wof:lastmodified":1694498071,
+    "wof:lastmodified":1695886270,
     "wof:name":"Byeshankovichy",
     "wof:parent_id":85669301,
     "wof:placetype":"county",

--- a/data/109/200/518/3/1092005183.geojson
+++ b/data/109/200/518/3/1092005183.geojson
@@ -133,8 +133,10 @@
     ],
     "wof:breaches":[],
     "wof:concordances":{
-        "hasc:id":"BY.VI.CN"
+        "hasc:id":"BY.VI.CN",
+        "meso:local_id":"103"
     },
+    "wof:concordances_official":"meso:local_id",
     "wof:country":"BY",
     "wof:created":1473896743,
     "wof:geomhash":"7d809923ad2dcee96be9dca84b3619fc",
@@ -147,7 +149,7 @@
         }
     ],
     "wof:id":1092005183,
-    "wof:lastmodified":1694497835,
+    "wof:lastmodified":1695886280,
     "wof:name":"Chashniki",
     "wof:parent_id":85669301,
     "wof:placetype":"county",

--- a/data/109/200/521/9/1092005219.geojson
+++ b/data/109/200/521/9/1092005219.geojson
@@ -127,8 +127,10 @@
     ],
     "wof:breaches":[],
     "wof:concordances":{
-        "hasc:id":"BY.VI.DK"
+        "hasc:id":"BY.VI.DK",
+        "meso:local_id":"104"
     },
+    "wof:concordances_official":"meso:local_id",
     "wof:country":"BY",
     "wof:created":1473896744,
     "wof:geomhash":"bc56dfb63194bbd329b4cfa1d88b0d28",
@@ -141,7 +143,7 @@
         }
     ],
     "wof:id":1092005219,
-    "wof:lastmodified":1694497835,
+    "wof:lastmodified":1695886279,
     "wof:name":"Dokshytsy",
     "wof:parent_id":85669301,
     "wof:placetype":"county",

--- a/data/109/200/524/9/1092005249.geojson
+++ b/data/109/200/524/9/1092005249.geojson
@@ -133,8 +133,10 @@
     ],
     "wof:breaches":[],
     "wof:concordances":{
-        "hasc:id":"BY.VI.DU"
+        "hasc:id":"BY.VI.DU",
+        "meso:local_id":"105"
     },
+    "wof:concordances_official":"meso:local_id",
     "wof:country":"BY",
     "wof:created":1473896745,
     "wof:geomhash":"1dc4c09f48489e9ef1251b266208411f",
@@ -147,7 +149,7 @@
         }
     ],
     "wof:id":1092005249,
-    "wof:lastmodified":1694497836,
+    "wof:lastmodified":1695886283,
     "wof:name":"Dubrowna",
     "wof:parent_id":85669301,
     "wof:placetype":"county",

--- a/data/109/200/526/9/1092005269.geojson
+++ b/data/109/200/526/9/1092005269.geojson
@@ -130,8 +130,10 @@
     ],
     "wof:breaches":[],
     "wof:concordances":{
-        "hasc:id":"BY.VI.GD"
+        "hasc:id":"BY.VI.GD",
+        "meso:local_id":"106"
     },
+    "wof:concordances_official":"meso:local_id",
     "wof:country":"BY",
     "wof:created":1473896746,
     "wof:geomhash":"6e7751d0bf4686d3f70696d553b988e1",
@@ -144,7 +146,7 @@
         }
     ],
     "wof:id":1092005269,
-    "wof:lastmodified":1694497835,
+    "wof:lastmodified":1695886279,
     "wof:name":"Haradok",
     "wof:parent_id":85669301,
     "wof:placetype":"county",

--- a/data/109/200/530/1/1092005301.geojson
+++ b/data/109/200/530/1/1092005301.geojson
@@ -139,8 +139,10 @@
     ],
     "wof:breaches":[],
     "wof:concordances":{
-        "hasc:id":"BY.VI.GB"
+        "hasc:id":"BY.VI.GB",
+        "meso:local_id":"107"
     },
+    "wof:concordances_official":"meso:local_id",
     "wof:country":"BY",
     "wof:created":1473896747,
     "wof:geomhash":"350148ac72a8d967bd542382acbaebfb",
@@ -153,7 +155,7 @@
         }
     ],
     "wof:id":1092005301,
-    "wof:lastmodified":1694497835,
+    "wof:lastmodified":1695886280,
     "wof:name":"Hlybokaye",
     "wof:parent_id":85669301,
     "wof:placetype":"county",

--- a/data/109/200/532/9/1092005329.geojson
+++ b/data/109/200/532/9/1092005329.geojson
@@ -70,8 +70,10 @@
     ],
     "wof:breaches":[],
     "wof:concordances":{
-        "hasc:id":"BY.VI.LP"
+        "hasc:id":"BY.VI.LP",
+        "meso:local_id":"108"
     },
+    "wof:concordances_official":"meso:local_id",
     "wof:country":"BY",
     "wof:created":1473896748,
     "wof:geomhash":"135022720db73a2a61cc9df65b89c66b",
@@ -84,7 +86,7 @@
         }
     ],
     "wof:id":1092005329,
-    "wof:lastmodified":1694498074,
+    "wof:lastmodified":1695886341,
     "wof:name":"Lyepyel",
     "wof:parent_id":85669301,
     "wof:placetype":"county",

--- a/data/109/200/533/9/1092005339.geojson
+++ b/data/109/200/533/9/1092005339.geojson
@@ -70,8 +70,10 @@
     ],
     "wof:breaches":[],
     "wof:concordances":{
-        "hasc:id":"BY.VI.LZ"
+        "hasc:id":"BY.VI.LZ",
+        "meso:local_id":"109"
     },
+    "wof:concordances_official":"meso:local_id",
     "wof:country":"BY",
     "wof:created":1473896749,
     "wof:geomhash":"ff95ac5be1627d471f602f37cb2a85fa",
@@ -84,7 +86,7 @@
         }
     ],
     "wof:id":1092005339,
-    "wof:lastmodified":1694498074,
+    "wof:lastmodified":1695886341,
     "wof:name":"Lyozna",
     "wof:parent_id":85669301,
     "wof:placetype":"county",

--- a/data/109/200/541/1/1092005411.geojson
+++ b/data/109/200/541/1/1092005411.geojson
@@ -136,8 +136,10 @@
     ],
     "wof:breaches":[],
     "wof:concordances":{
-        "hasc:id":"BY.VI.MR"
+        "hasc:id":"BY.VI.MR",
+        "meso:local_id":"110"
     },
+    "wof:concordances_official":"meso:local_id",
     "wof:country":"BY",
     "wof:created":1473896750,
     "wof:geomhash":"9a00bb52bbf553fca871f980eabda2f6",
@@ -150,7 +152,7 @@
         }
     ],
     "wof:id":1092005411,
-    "wof:lastmodified":1694497836,
+    "wof:lastmodified":1695886283,
     "wof:name":"Myory",
     "wof:parent_id":85669301,
     "wof:placetype":"county",

--- a/data/109/200/544/5/1092005445.geojson
+++ b/data/109/200/544/5/1092005445.geojson
@@ -148,8 +148,10 @@
     ],
     "wof:breaches":[],
     "wof:concordances":{
-        "hasc:id":"BY.VI.PV"
+        "hasc:id":"BY.VI.PV",
+        "meso:local_id":"111"
     },
+    "wof:concordances_official":"meso:local_id",
     "wof:country":"BY",
     "wof:created":1473896755,
     "wof:geomhash":"812fee572d63eff74723318a94c65d80",
@@ -162,7 +164,7 @@
         }
     ],
     "wof:id":1092005445,
-    "wof:lastmodified":1694497835,
+    "wof:lastmodified":1695886280,
     "wof:name":"Pastavy",
     "wof:parent_id":85669301,
     "wof:placetype":"county",

--- a/data/109/200/546/3/1092005463.geojson
+++ b/data/109/200/546/3/1092005463.geojson
@@ -70,8 +70,10 @@
     ],
     "wof:breaches":[],
     "wof:concordances":{
-        "hasc:id":"BY.VI.PL"
+        "hasc:id":"BY.VI.PL",
+        "meso:local_id":"112"
     },
+    "wof:concordances_official":"meso:local_id",
     "wof:country":"BY",
     "wof:created":1473896756,
     "wof:geomhash":"3cccfa6c87fa3161c6de259d2a126e8a",
@@ -84,7 +86,7 @@
         }
     ],
     "wof:id":1092005463,
-    "wof:lastmodified":1694498075,
+    "wof:lastmodified":1695886382,
     "wof:name":"Polatsak",
     "wof:parent_id":85669301,
     "wof:placetype":"county",

--- a/data/109/200/546/5/1092005465.geojson
+++ b/data/109/200/546/5/1092005465.geojson
@@ -70,8 +70,10 @@
     ],
     "wof:breaches":[],
     "wof:concordances":{
-        "hasc:id":"BY.VI.RS"
+        "hasc:id":"BY.VI.RS",
+        "meso:local_id":"113"
     },
+    "wof:concordances_official":"meso:local_id",
     "wof:country":"BY",
     "wof:created":1473896757,
     "wof:geomhash":"e6f4eefe2dae7766e015ca8931a6680c",
@@ -84,7 +86,7 @@
         }
     ],
     "wof:id":1092005465,
-    "wof:lastmodified":1694498075,
+    "wof:lastmodified":1695886390,
     "wof:name":"Rasony",
     "wof:parent_id":85669301,
     "wof:placetype":"county",

--- a/data/109/200/547/1/1092005471.geojson
+++ b/data/109/200/547/1/1092005471.geojson
@@ -109,8 +109,10 @@
     ],
     "wof:breaches":[],
     "wof:concordances":{
-        "hasc:id":"BY.VI.SA"
+        "hasc:id":"BY.VI.SA",
+        "meso:local_id":"114"
     },
+    "wof:concordances_official":"meso:local_id",
     "wof:country":"BY",
     "wof:created":1473896758,
     "wof:geomhash":"d214f823aff430c0e6dc449743fc7ff6",
@@ -123,7 +125,7 @@
         }
     ],
     "wof:id":1092005471,
-    "wof:lastmodified":1694497836,
+    "wof:lastmodified":1695886283,
     "wof:name":"Sharkawshchyna",
     "wof:parent_id":85669301,
     "wof:placetype":"county",

--- a/data/109/200/550/1/1092005501.geojson
+++ b/data/109/200/550/1/1092005501.geojson
@@ -70,8 +70,10 @@
     ],
     "wof:breaches":[],
     "wof:concordances":{
-        "hasc:id":"BY.VI.SI"
+        "hasc:id":"BY.VI.SI",
+        "meso:local_id":"115"
     },
+    "wof:concordances_official":"meso:local_id",
     "wof:country":"BY",
     "wof:created":1473896759,
     "wof:geomhash":"efba73348d627decc91191724c6bfaf1",
@@ -84,7 +86,7 @@
         }
     ],
     "wof:id":1092005501,
-    "wof:lastmodified":1694498075,
+    "wof:lastmodified":1695886398,
     "wof:name":"Shumilina",
     "wof:parent_id":85669301,
     "wof:placetype":"county",

--- a/data/109/200/554/5/1092005545.geojson
+++ b/data/109/200/554/5/1092005545.geojson
@@ -127,8 +127,10 @@
     ],
     "wof:breaches":[],
     "wof:concordances":{
-        "hasc:id":"BY.VI.SE"
+        "hasc:id":"BY.VI.SE",
+        "meso:local_id":"116"
     },
+    "wof:concordances_official":"meso:local_id",
     "wof:country":"BY",
     "wof:created":1473896761,
     "wof:geomhash":"56ea8c1682931374aa2832a15ee1a3f5",
@@ -141,7 +143,7 @@
         }
     ],
     "wof:id":1092005545,
-    "wof:lastmodified":1694497835,
+    "wof:lastmodified":1695886281,
     "wof:name":"Syanno",
     "wof:parent_id":85669301,
     "wof:placetype":"county",

--- a/data/109/200/556/5/1092005565.geojson
+++ b/data/109/200/556/5/1092005565.geojson
@@ -133,8 +133,10 @@
     ],
     "wof:breaches":[],
     "wof:concordances":{
-        "hasc:id":"BY.VI.TO"
+        "hasc:id":"BY.VI.TO",
+        "meso:local_id":"117"
     },
+    "wof:concordances_official":"meso:local_id",
     "wof:country":"BY",
     "wof:created":1473896762,
     "wof:geomhash":"91a93a10eb49704a6be5e9b0ac4a81e6",
@@ -147,7 +149,7 @@
         }
     ],
     "wof:id":1092005565,
-    "wof:lastmodified":1694497833,
+    "wof:lastmodified":1695886275,
     "wof:name":"Talachyn",
     "wof:parent_id":85669301,
     "wof:placetype":"county",

--- a/data/109/200/559/9/1092005599.geojson
+++ b/data/109/200/559/9/1092005599.geojson
@@ -70,8 +70,10 @@
     ],
     "wof:breaches":[],
     "wof:concordances":{
-        "hasc:id":"BY.VI.US"
+        "hasc:id":"BY.VI.US",
+        "meso:local_id":"118"
     },
+    "wof:concordances_official":"meso:local_id",
     "wof:country":"BY",
     "wof:created":1473896763,
     "wof:geomhash":"37ad92874ee6ee4c06847893d20e0af8",
@@ -84,7 +86,7 @@
         }
     ],
     "wof:id":1092005599,
-    "wof:lastmodified":1694498077,
+    "wof:lastmodified":1695886417,
     "wof:name":"Ushat",
     "wof:parent_id":85669301,
     "wof:placetype":"county",

--- a/data/109/200/560/5/1092005605.geojson
+++ b/data/109/200/560/5/1092005605.geojson
@@ -70,8 +70,10 @@
     ],
     "wof:breaches":[],
     "wof:concordances":{
-        "hasc:id":"BY.VI.VB"
+        "hasc:id":"BY.VI.VB",
+        "meso:local_id":"119"
     },
+    "wof:concordances_official":"meso:local_id",
     "wof:country":"BY",
     "wof:created":1473896764,
     "wof:geomhash":"2947f4b7445402ff05c66705e0899994",
@@ -84,7 +86,7 @@
         }
     ],
     "wof:id":1092005605,
-    "wof:lastmodified":1694498077,
+    "wof:lastmodified":1695886418,
     "wof:name":"Vitsyebsk",
     "wof:parent_id":85669301,
     "wof:placetype":"county",

--- a/data/109/200/560/7/1092005607.geojson
+++ b/data/109/200/560/7/1092005607.geojson
@@ -70,8 +70,10 @@
     ],
     "wof:breaches":[],
     "wof:concordances":{
-        "hasc:id":"BY.VI.VH"
+        "hasc:id":"BY.VI.VH",
+        "meso:local_id":"120"
     },
+    "wof:concordances_official":"meso:local_id",
     "wof:country":"BY",
     "wof:created":1473896765,
     "wof:geomhash":"90962ab31fcec7509d9bc2f17373e81d",
@@ -84,7 +86,7 @@
         }
     ],
     "wof:id":1092005607,
-    "wof:lastmodified":1694498077,
+    "wof:lastmodified":1695886418,
     "wof:name":"Vyerkhnyazdvinsk",
     "wof:parent_id":85669301,
     "wof:placetype":"county",

--- a/data/856/323/95/85632395.geojson
+++ b/data/856/323/95/85632395.geojson
@@ -1410,6 +1410,7 @@
         "hasc:id":"BY",
         "icao:code":"EW",
         "ioc:id":"BLR",
+        "iso:code":"BY",
         "itu:id":"BLR",
         "m49:code":"112",
         "marc:id":"bw",
@@ -1423,6 +1424,7 @@
         "wk:page":"Belarus",
         "wmo:id":"BY"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"BY",
     "wof:country_alpha3":"BLR",
     "wof:geom_alt":[
@@ -1446,7 +1448,7 @@
         "bel",
         "rus"
     ],
-    "wof:lastmodified":1694639671,
+    "wof:lastmodified":1695881330,
     "wof:name":"Belarus",
     "wof:parent_id":102191581,
     "wof:placetype":"country",

--- a/data/856/692/87/85669287.geojson
+++ b/data/856/692/87/85669287.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":4.362301,
-    "geom:area_square_m":32923558302.116848,
+    "geom:area_square_m":32923557951.495934,
     "geom:bbox":"23.178943,51.498054,27.624575,53.412344",
     "geom:latitude":52.383059,
     "geom:longitude":25.489385,
@@ -386,16 +386,18 @@
         "gn:id":629631,
         "gp:id":2344830,
         "hasc:id":"BY.BR",
+        "iso:code":"BY-BR",
         "iso:id":"BY-BR",
         "qs_pg:id":219515,
         "wd:id":"Q173822",
         "wk:page":"Brest Region"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"BY",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"010576f8692c6efbd7e55e8c989a0bfe",
+    "wof:geomhash":"f3b99ccbf4e8538e6df311f89be178ab",
     "wof:hierarchy":[
         {
             "continent_id":102191581,
@@ -412,7 +414,7 @@
         "bel",
         "rus"
     ],
-    "wof:lastmodified":1690863650,
+    "wof:lastmodified":1695884481,
     "wof:name":"Brest",
     "wof:parent_id":85632395,
     "wof:placetype":"region",

--- a/data/856/692/91/85669291.geojson
+++ b/data/856/692/91/85669291.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":5.30318,
-    "geom:area_square_m":40099358596.458542,
+    "geom:area_square_m":40099359161.319237,
     "geom:bbox":"27.264823,51.262011,31.79927,53.352023",
     "geom:latitude":52.300183,
     "geom:longitude":29.662461,
@@ -399,16 +399,18 @@
         "gn:id":628281,
         "gp:id":2344831,
         "hasc:id":"BY.HO",
+        "iso:code":"BY-HO",
         "iso:id":"BY-HO",
         "qs_pg:id":423611,
         "wd:id":"Q188732",
         "wk:page":"Gomel Region"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"BY",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"e600166d33c4c097552f9d6d5051dbb4",
+    "wof:geomhash":"c178b09097647dd4139f025cf8bb2635",
     "wof:hierarchy":[
         {
             "continent_id":102191581,
@@ -425,7 +427,7 @@
         "bel",
         "rus"
     ],
-    "wof:lastmodified":1690863651,
+    "wof:lastmodified":1695884483,
     "wof:name":"Gomel",
     "wof:parent_id":85632395,
     "wof:placetype":"region",

--- a/data/856/692/95/85669295.geojson
+++ b/data/856/692/95/85669295.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":3.932339,
-    "geom:area_square_m":28847756666.940346,
+    "geom:area_square_m":28847756960.723057,
     "geom:bbox":"28.091364,52.677913,32.77682,54.474787",
     "geom:latitude":53.608925,
     "geom:longitude":30.442337,
@@ -402,16 +402,18 @@
         "gn:id":625073,
         "gp:id":2344833,
         "hasc:id":"BY.HM",
+        "iso:code":"BY-HM",
         "iso:id":"BY-HM",
         "qs_pg:id":219516,
         "wd:id":"Q189822",
         "wk:page":"Mogilev Region"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"BY",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"cac1fd344c270c0f1affc76a31840054",
+    "wof:geomhash":"01a611ae9ce58d762ca2fdd6d139b3ef",
     "wof:hierarchy":[
         {
             "continent_id":102191581,
@@ -428,7 +430,7 @@
         "bel",
         "rus"
     ],
-    "wof:lastmodified":1690863650,
+    "wof:lastmodified":1695884482,
     "wof:name":"Mogilev",
     "wof:parent_id":85632395,
     "wof:placetype":"region",

--- a/data/856/693/01/85669301.geojson
+++ b/data/856/693/01/85669301.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":5.667303,
-    "geom:area_square_m":39974794355.148857,
+    "geom:area_square_m":39974794616.235298,
     "geom:bbox":"26.212946,54.221583,31.210223,56.172485",
     "geom:latitude":55.218113,
     "geom:longitude":28.936088,
@@ -401,16 +401,18 @@
         "gn:id":620134,
         "gp:id":2344835,
         "hasc:id":"BY.VI",
+        "iso:code":"BY-VI",
         "iso:id":"BY-VI",
         "qs_pg:id":1285053,
         "wd:id":"Q185700",
         "wk:page":"Vitebsk Region"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"BY",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"3eb9d08d67e1c9839d29c3ed4b8dab50",
+    "wof:geomhash":"969c2ba063e2557c7c1213cf34b6969d",
     "wof:hierarchy":[
         {
             "continent_id":102191581,
@@ -427,7 +429,7 @@
         "bel",
         "rus"
     ],
-    "wof:lastmodified":1690863649,
+    "wof:lastmodified":1695884482,
     "wof:name":"Vitebsk",
     "wof:parent_id":85632395,
     "wof:placetype":"region",

--- a/data/856/693/05/85669305.geojson
+++ b/data/856/693/05/85669305.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":3.418786,
-    "geom:area_square_m":25010258907.00462,
+    "geom:area_square_m":25010259243.302692,
     "geom:bbox":"23.510962,52.750319,26.701901,55.01531",
     "geom:latitude":53.726078,
     "geom:longitude":25.175492,
@@ -400,15 +400,17 @@
         "gn:id":628035,
         "gp:id":2344832,
         "hasc:id":"BY.HR",
+        "iso:code":"BY-HR",
         "iso:id":"BY-HR",
         "qs_pg:id":239501,
         "wd:id":"Q191061"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"BY",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"acac02d3201289f73fc26c74e3f0b168",
+    "wof:geomhash":"a0bd3c0170bb77a635735f05a63d6248",
     "wof:hierarchy":[
         {
             "continent_id":102191581,
@@ -425,7 +427,7 @@
         "bel",
         "rus"
     ],
-    "wof:lastmodified":1690863648,
+    "wof:lastmodified":1695884482,
     "wof:name":"Grodno",
     "wof:parent_id":85632395,
     "wof:placetype":"region",

--- a/data/856/693/09/85669309.geojson
+++ b/data/856/693/09/85669309.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":5.148422,
-    "geom:area_square_m":37631960705.708992,
+    "geom:area_square_m":37631960067.936432,
     "geom:bbox":"26.014353,52.402275,29.508949,55.018862",
     "geom:latitude":53.760231,
     "geom:longitude":27.694015,
@@ -400,16 +400,18 @@
         "gn:id":625142,
         "gp:id":2344834,
         "hasc:id":"BY.MI",
+        "iso:code":"BY-MI",
         "iso:id":"BY-MI",
         "qs_pg:id":318313,
         "wd:id":"Q192959",
         "wk:page":"Minsk Region"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"BY",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"338b8840d1fd4eb9929001562656f757",
+    "wof:geomhash":"49649f5c02903ba846fe9d14eb3dcdf6",
     "wof:hierarchy":[
         {
             "continent_id":102191581,
@@ -426,7 +428,7 @@
         "bel",
         "rus"
     ],
-    "wof:lastmodified":1690863648,
+    "wof:lastmodified":1695884483,
     "wof:name":"Minsk",
     "wof:parent_id":85632395,
     "wof:placetype":"region",

--- a/data/856/693/13/85669313.geojson
+++ b/data/856/693/13/85669313.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.310368,
-    "geom:area_square_m":2259250948.567038,
+    "geom:area_square_m":2259250948.566989,
     "geom:bbox":"27.015838,53.626487,27.980596,54.262204",
     "geom:latitude":53.935773,
     "geom:longitude":27.51748,
@@ -771,12 +771,14 @@
         "gn:id":625143,
         "gp:id":20069996,
         "hasc:id":"BY.MA",
+        "iso:code":"BY-MA",
         "iso:id":"BY-MA",
         "loc:id":"n79116460",
         "qs_pg:id":1118659,
         "wd:id":"Q2280",
         "wk:page":"Minsk"
     },
+    "wof:concordances_official":"iso:code",
     "wof:coterminous":[
         890443331
     ],
@@ -784,7 +786,7 @@
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"6d402b1c968d9c18faeea34a7e7e36a1",
+    "wof:geomhash":"9b1e9e0217e8b495a5456d2cde2262ae",
     "wof:hierarchy":[
         {
             "continent_id":102191581,
@@ -802,7 +804,7 @@
         "bel",
         "rus"
     ],
-    "wof:lastmodified":1690863649,
+    "wof:lastmodified":1695884442,
     "wof:name":"City of Minsk",
     "wof:parent_id":85632395,
     "wof:placetype":"region",

--- a/data/890/422/309/890422309.geojson
+++ b/data/890/422/309/890422309.geojson
@@ -245,8 +245,10 @@
     "wof:concordances":{
         "gn:id":828881,
         "hasc:id":"BY.BR.BR",
+        "meso:local_id":"3",
         "qs_pg:id":554243
     },
+    "wof:concordances_official":"meso:local_id",
     "wof:country":"BY",
     "wof:created":1469051436,
     "wof:geom_alt":[
@@ -262,7 +264,7 @@
         }
     ],
     "wof:id":890422309,
-    "wof:lastmodified":1694497895,
+    "wof:lastmodified":1695886758,
     "wof:name":"Brest",
     "wof:parent_id":85669287,
     "wof:placetype":"county",

--- a/data/890/428/903/890428903.geojson
+++ b/data/890/428/903/890428903.geojson
@@ -93,8 +93,10 @@
     "wof:concordances":{
         "gn:id":828847,
         "hasc:id":"BY.HR.HR",
+        "meso:local_id":"42",
         "qs_pg:id":83836
     },
+    "wof:concordances_official":"meso:local_id",
     "wof:country":"BY",
     "wof:created":1469051779,
     "wof:geom_alt":[
@@ -110,7 +112,7 @@
         }
     ],
     "wof:id":890428903,
-    "wof:lastmodified":1694498072,
+    "wof:lastmodified":1695886301,
     "wof:name":"Hrodna",
     "wof:parent_id":85669305,
     "wof:placetype":"county",

--- a/data/890/455/745/890455745.geojson
+++ b/data/890/455/745/890455745.geojson
@@ -242,8 +242,10 @@
     "wof:concordances":{
         "gn:id":828907,
         "hasc:id":"BY.MI.BO",
+        "meso:local_id":"78",
         "qs_pg:id":554268
     },
+    "wof:concordances_official":"meso:local_id",
     "wof:country":"BY",
     "wof:created":1469052973,
     "wof:geom_alt":[
@@ -259,7 +261,7 @@
         }
     ],
     "wof:id":890455745,
-    "wof:lastmodified":1694497895,
+    "wof:lastmodified":1695886758,
     "wof:name":"Barysaw",
     "wof:parent_id":85669309,
     "wof:placetype":"county",


### PR DESCRIPTION
Will fix a portion of https://github.com/whosonfirst-data/whosonfirst-data/issues/2164. Sets wof:concordances_official, wof:concordances_official_alt, and wof:label_*_x_preferred properties, and wof:concordances{*:*} hashes when approprirate.